### PR TITLE
Add basic auth and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,29 @@
 # User intent survey explorer
 
 Prototype to help make sense of user intent survey data.
+
+## Deployment
+
+The application is deployed on the Paas and has a IP whitelist router sitting in
+front of it to lock it down to office IPs.
+
+To deploy the application, follow the [getting started guide for GOV.UK
+PaaS](https://docs.cloud.service.gov.uk/get_started.html#get-started) to set up
+your account and the `cf` command line.
+
+You can push a new version with:
+
+```
+cf push
+```
+
+## Authentication
+
+When the Rails environment is `production`, the application is protected by
+basic authentication. You can set the user name and password by creating the two
+expected environment variables on the Paas:
+
+```
+cf set-env govuk-user-intent-survey-explorer GOVUK_USERNAME <value>
+cf set-env govuk-user-intent-survey-explorer GOVUK_PASSWORD <value>
+```

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::Base
+  http_basic_authenticate_with name: ENV["GOVUK_USERNAME"], password: ENV["GOVUK_PASSWORD"], if: -> { Rails.env == "production" }
 end


### PR DESCRIPTION
Add basic auth to the ApplicationController so that the application
challenges for a username and password when the Rails.env is production.

Update the README to include deployment instructions and a note about
the router that is sitting in front of the application now. Also include
instructions to set the authentication env vars using `cf`.

[Trello](https://trello.com/c/GPW8XB6L/306-add-some-auth-to-the-user-intent-survey-app)