### PR TITLE
Set up postgres for production

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: rake db:migrate && bin/rails server

--- a/config/database.yml
+++ b/config/database.yml
@@ -21,5 +21,7 @@ test:
   database: db/test.sqlite3
 
 production:
-  <<: *default
-  database: db/production.sqlite3
+  adapter: postgresql
+  encoding: unicode
+  pool: 12
+  database: <%= ENV["DATABASE_URL"] %>

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,8 @@
 ---
 applications:
 - name: govuk-user-intent-survey-explorer
+  services:
+  - govuk-pg-user-intent-survey-explorer
   memory: 256M
   buildpacks:
   - ruby_buildpack


### PR DESCRIPTION
On the PaaS we will rely on postgres.

[Trello](https://trello.com/c/ZgE5HgwF/323-spike-using-sqlite-on-paas)