### PR TITLE
Add erd to generate database diagrams

### DIFF
--- a/.erdconfig
+++ b/.erdconfig
@@ -1,0 +1,22 @@
+attributes:
+  - content
+  - foreign_key
+  - inheritance
+disconnected: true
+filename: erd
+filetype: pdf
+indirect: true
+inheritance: false
+markup: true
+notation: crowsfoot
+orientation: horizontal
+polymorphism: false
+sort: true
+warn: true
+title: GOV.UK User Intent Survey Explorer
+exclude: null
+only: null
+only_recursion_depth: null
+prepend_primary: false
+cluster: false
+splines: spline

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+# Ignore database diagram output
+/doc/database-diagram.pdf

--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ group :development do
   # Access an interactive console on exception pages or by calling "console" anywhere in the code.
   gem "listen", ">= 3.0.5", "< 3.2"
   gem "web-console", ">= 3.3.0"
+  gem "rails-erd", "~> 1.6"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,7 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.1)
+    choice (0.2.0)
     concurrent-ruby (1.1.5)
     crass (1.0.6)
     diff-lcs (1.3)
@@ -170,6 +171,11 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
+    rails-erd (1.6.0)
+      activerecord (>= 4.2)
+      activesupport (>= 4.2)
+      choice (~> 0.2.0)
+      ruby-graphviz (~> 1.2)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
     railties (6.0.2.1)
@@ -225,6 +231,7 @@ GEM
       rubocop (>= 0.72.0)
     rubocop-rspec (1.37.1)
       rubocop (>= 0.68.1)
+    ruby-graphviz (1.2.4)
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
     sass (3.7.4)
@@ -291,6 +298,7 @@ DEPENDENCIES
   pg (~> 1)
   puma (~> 4.1)
   rails (~> 6.0.2, >= 6.0.2.1)
+  rails-erd (~> 1.6)
   rspec-rails (~> 3)
   rubocop-govuk (~> 2)
   sass-rails (< 6)
@@ -302,4 +310,4 @@ RUBY VERSION
    ruby 2.6.5p114
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/README.md
+++ b/README.md
@@ -27,3 +27,15 @@ expected environment variables on the Paas:
 cf set-env govuk-user-intent-survey-explorer GOVUK_USERNAME <value>
 cf set-env govuk-user-intent-survey-explorer GOVUK_PASSWORD <value>
 ```
+
+## Creating an up-to-date database diagram
+
+To create an up-to-date database diagram, we're using `rails-erd`.
+
+To run, ensure you have Graphviz installed on your system (see https://voormedia.github.io/rails-erd/install.html).
+
+When you're ready, run:
+
+`erd --filename "doc/database-diagram"`
+
+This will create the database diagram in the `doc` directory. Note that we didn't run `erd` in the context of Rake - if you try this you'll get a `No models found` error.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -6,8 +6,9 @@ Rails.application.configure do
   # since you don't have to restart the web server when you make code changes.
   config.cache_classes = false
 
-  # Do not eager load code on boot.
-  config.eager_load = false
+  # Eager load code on boot.
+  # We're loading here to enable erd to produce database diagrams.
+  config.eager_load = true
 
   # Show full error reports.
   config.consider_all_requests_local = true


### PR DESCRIPTION
This PR adds gem `rails-erd` to generate database diagrams from the ActiveRecord models.

Example output:

<img width="1395" alt="Screenshot 2020-02-28 at 16 44 02" src="https://user-images.githubusercontent.com/5422487/75567483-893fe580-5a49-11ea-91f8-b163204e0c7d.png">

Trello: https://trello.com/c/ieoWPrbp
