### PR TITLE
Add overview page to explorer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,8 @@ gem 'elasticsearch-rails', '~> 6.1.0'
 gem 'elasticsearch-model', '~> 6.1.0'
 gem 'elasticsearch-persistence', '~> 6.1.0'
 
+gem 'kaminari'
+
 group :development, :test do
   # Call "byebug" anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: %i(mri mingw x64_mingw)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,6 +130,18 @@ GEM
     jaro_winkler (1.5.4)
     jbuilder (2.9.1)
       activesupport (>= 4.2.0)
+    kaminari (1.2.0)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.0)
+      kaminari-activerecord (= 1.2.0)
+      kaminari-core (= 1.2.0)
+    kaminari-actionview (1.2.0)
+      actionview
+      kaminari-core (= 1.2.0)
+    kaminari-activerecord (1.2.0)
+      activerecord
+      kaminari-core (= 1.2.0)
+    kaminari-core (1.2.0)
     kgio (2.11.3)
     kramdown (2.1.0)
     link_header (0.0.8)
@@ -331,6 +343,7 @@ DEPENDENCIES
   elasticsearch-rails (~> 6.1.0)
   govuk_publishing_components (~> 21.21)
   jbuilder (~> 2.7)
+  kaminari
   listen (>= 3.0.5, < 3.2)
   pg (~> 1)
   puma (~> 4.3)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,2 +1,6 @@
 @import "govuk_publishing_components/all_components";
 @import "overwrites";
+
+.govuk-table__cell {
+  word-break: break-all;
+}

--- a/app/assets/stylesheets/summary.scss
+++ b/app/assets/stylesheets/summary.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Summary controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/summary_controller.rb
+++ b/app/controllers/summary_controller.rb
@@ -1,0 +1,33 @@
+class SummaryController < ApplicationController
+
+  def index
+    @presenter = SummaryPresenter.new(results, search_params)
+  end
+
+private
+
+  def results
+    Page.find_by_sql(["select pages.id, pages.base_path, count(page_visits.visit_id) as total_pageviews, count(distinct(page_visits.visit_id)) as unique_visits from pages join page_visits on page_visits.page_id = pages.id where pages.base_path like ? group by pages.id, pages.base_path order by #{search_params[:sort_key]} #{search_params[:sort_direction]};", "%#{search_params[:q]}%"])
+  end
+
+  def search_params
+    @search_params ||= begin
+      sort_keys = ["base_path", "total_pageviews", "unique_visits"]
+
+      defaults = {
+        q: '',
+        page: 1
+      }.merge(
+        params.permit(
+          :q,
+          :page,
+        ).to_h.symbolize_keys
+      )
+
+      defaults[:sort_key] = sort_keys.include?(params[:sort_key]) ? params[:sort_key] : "total_pageviews"
+      defaults[:sort_direction] = params[:sort_direction] == "asc" ? :asc : :desc
+
+      defaults
+    end
+  end
+end

--- a/app/helpers/summary_helper.rb
+++ b/app/helpers/summary_helper.rb
@@ -37,18 +37,18 @@ module SummaryHelper
   def get_table_headers
     column_map = {
       "base_path" => {
-        text: "Base path",
+        text: "Page",
         href: "/summary?sort_key=base_path&sort_direction=asc&q=#{params[:q]}"
       },
-      "total_pageviews" => {
-        text: "Total Pageviews",
-        format: "numeric",
-        href: "/summary?sort_key=total_pageviews&sort_direction=asc&q=#{params[:q]}"
-      },
       "unique_visits" => {
-        text: "Unique Visits",
+        text: "Unique page views",
         format: "numeric",
         href: "/summary?sort_key=unique_visits&sort_direction=asc&q=#{params[:q]}"
+      },
+      "total_pageviews" => {
+        text: "Page views",
+        format: "numeric",
+        href: "/summary?sort_key=total_pageviews&sort_direction=asc&q=#{params[:q]}"
       }
     }
 
@@ -75,11 +75,11 @@ module SummaryHelper
           text: link
         },
         {
-          text: page.total_pageviews,
+          text: page.unique_visits,
           format: 'numeric'
         },
         {
-          text: page.unique_visits,
+          text: page.total_pageviews,
           format: 'numeric'
         }
       ]

--- a/app/helpers/summary_helper.rb
+++ b/app/helpers/summary_helper.rb
@@ -1,0 +1,88 @@
+module SummaryHelper
+  include Kaminari::Helpers::HelperMethods
+
+  def sort_directions
+    {
+      asc: "ascending",
+      desc: "descending"
+    }
+  end
+
+  def navigation_links
+    links = {}
+
+    if @presenter.pagination.page > 1
+      links = links.merge(
+        previous_page: {
+          url: path_to_previous_page(@presenter.content_pages),
+          title: "Previous page",
+          label: "#{@presenter.pagination.page - 1} of #{@presenter.pagination.total_pages}"
+        }
+      )
+    end
+
+    if @presenter.pagination.page < @presenter.pagination.total_pages
+      links = links.merge(
+        next_page: {
+          url: path_to_next_page(@presenter.content_pages),
+          title: "Next page",
+          label: "#{@presenter.pagination.page + 1} of #{@presenter.pagination.total_pages}"
+        }
+      )
+    end
+
+    links
+  end
+
+  def get_table_headers
+    column_map = {
+      "base_path" => {
+        text: "Base path",
+        href: "/summary?sort_key=base_path&sort_direction=asc&q=#{params[:q]}"
+      },
+      "total_pageviews" => {
+        text: "Total Pageviews",
+        format: "numeric",
+        href: "/summary?sort_key=total_pageviews&sort_direction=asc&q=#{params[:q]}"
+      },
+      "unique_visits" => {
+        text: "Unique Visits",
+        format: "numeric",
+        href: "/summary?sort_key=unique_visits&sort_direction=asc&q=#{params[:q]}"
+      }
+    }
+
+    unless @presenter.sorting.sort_key.blank?
+      dir = @presenter.sorting.sort_direction == :asc ? :desc : :asc
+      column_map[@presenter.sorting.sort_key].merge!(
+        {
+          sort_direction: sort_directions[@presenter.sorting.sort_direction],
+          href: "/summary?sort_key=#{@presenter.sorting.sort_key}&sort_direction=#{dir}&page=#{@presenter.pagination.page}&q=#{params[:q]}"
+        }
+      )
+    end
+
+    column_map.values
+  end
+
+
+  def map_content_pages_to_table
+    @presenter.content_pages.map do |page|
+      link = link_to page.base_path, "/pages/#{page.id}"
+
+      [
+        {
+          text: link
+        },
+        {
+          text: page.total_pageviews,
+          format: 'numeric'
+        },
+        {
+          text: page.unique_visits,
+          format: 'numeric'
+        }
+      ]
+    end
+  end
+end

--- a/app/presenters/pagination_presenter.rb
+++ b/app/presenters/pagination_presenter.rb
@@ -1,0 +1,16 @@
+class PaginationPresenter
+  include Kaminari::Helpers::HelperMethods
+  attr_reader :page, :total_items, :total_pages
+
+    def initialize(page: 1, total_items:)
+      @items_per_page = 15
+
+      @page = page.to_i
+      @total_items = total_items
+      @total_pages = (@total_items.to_f/@items_per_page).ceil()
+    end
+
+    def paginate(items)
+      Kaminari.paginate_array(items, total_count: total_items).page(page).per(@items_per_page)
+    end
+end

--- a/app/presenters/sort_presenter.rb
+++ b/app/presenters/sort_presenter.rb
@@ -1,0 +1,8 @@
+class SortPresenter
+  attr_reader :q, :sort_key, :sort_direction
+
+  def initialize(sort_key:, sort_direction:)
+    @sort_key = sort_key
+    @sort_direction = sort_direction.to_sym
+  end
+end

--- a/app/presenters/summary_presenter.rb
+++ b/app/presenters/summary_presenter.rb
@@ -1,0 +1,11 @@
+class SummaryPresenter
+  attr_reader :pagination, :sorting, :search_params, :content_pages
+
+  def initialize(items, search_params)
+    @search_params = search_params
+    @pagination = PaginationPresenter.new(page: search_params[:page], total_items: items.count)
+    @sorting = SortPresenter.new(sort_key: search_params[:sort_key], sort_direction: search_params[:sort_direction])
+
+    @content_pages = pagination.paginate(items)
+  end
+end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -3,6 +3,13 @@
 <%= render "govuk_publishing_components/components/document_list", {
   items: [
     {
+        link: {
+            text: "Summary",
+            path: summary_path,
+            description: "See summary."
+        }
+    },
+    {
       link: {
         text: "List of visits",
         path: visits_path,

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,6 +13,17 @@
   }%>
 
   <div class="govuk-width-container">
+    <div class="govuk-phase-banner">
+      <p class="govuk-phase-banner__content">
+        <strong class="govuk-tag govuk-phase-banner__content__tag">
+          alpha
+        </strong>
+        <span class="govuk-phase-banner__text">
+      This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.
+    </span>
+      </p>
+    </div>
+
     <main class="govuk-main-wrapper" id="main-content" role="main">
       <%= yield %>
     </main>

--- a/app/views/summary/index.html.erb
+++ b/app/views/summary/index.html.erb
@@ -1,0 +1,26 @@
+<%= form_with(url: "/summary", method: "get") do %>
+  <%= render "govuk_publishing_components/components/search", {
+      inline_label: false,
+      label_text: sanitize("<h1>Search pages by URL</h1>"),
+      value: params[:q]
+  } %>
+<% end %>
+
+<%= render "govuk_publishing_components/components/heading", {
+    text: "#{@presenter.pagination.total_items} results",
+    padding: true,
+} %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+
+    <%= render "govuk_publishing_components/components/table", {
+        sortable: true,
+        head: get_table_headers,
+        rows: map_content_pages_to_table
+    } %>
+
+  </div>
+</div>
+
+<%= render "govuk_publishing_components/components/previous_and_next_navigation", navigation_links %>

--- a/app/views/summary/index.html.erb
+++ b/app/views/summary/index.html.erb
@@ -1,15 +1,18 @@
+<h1 class="govuk-heading-xl">
+  User intent survey
+</h1>
+
+<p class="govuk-body govuk-!-margin-bottom-7">Last updated 6 April 2020 9:04am</p>
+
 <%= form_with(url: "/summary", method: "get") do %>
   <%= render "govuk_publishing_components/components/search", {
       inline_label: false,
-      label_text: sanitize("<h1>Search pages by URL</h1>"),
+      label_text: sanitize("<h1>Search for a title or URL</h1>"),
       value: params[:q]
   } %>
 <% end %>
 
-<%= render "govuk_publishing_components/components/heading", {
-    text: "#{@presenter.pagination.total_items} results",
-    padding: true,
-} %>
+<p class="govuk-body">Showing <span class="govuk-!-font-weight-bold"><%= @presenter.pagination.total_items %></span> content pages where users have given survey answers</p>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">

--- a/config/initializers/govuk_publishing_components.rb
+++ b/config/initializers/govuk_publishing_components.rb
@@ -1,5 +1,6 @@
 GovukPublishingComponents.configure do |c|
   c.component_guide_title = "User intent survey explorer component guide"
 
+  c.application_stylesheet
   c.application_print_stylesheet
 end

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  # config.default_per_page = 25
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
-  root to: "home#index"
+  root to: "summary#index"
   resources :visits, only: [:index, :show]
+
+  get "summary" => "summary#index", as: :summary
 
   get "pages/search" => "page_searches#show", as: :page_search
   resources :pages, only: [:show]

--- a/spec/controllers/summary_controller_spec.rb
+++ b/spec/controllers/summary_controller_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe SummaryController, type: :controller do
+
+  describe "GET #index" do
+    it "returns http success" do
+      get :index
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/helpers/summary_helper_spec.rb
+++ b/spec/helpers/summary_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the SummaryHelper. For example:
+#
+# describe SummaryHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe SummaryHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/summary/index.html.erb_spec.rb
+++ b/spec/views/summary/index.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "summary/index.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
This PR adds an overview page to the app, which allows users to see all of the pages that people who have filled out the survey have been to as part of their journeys. Users can filter down on this data, and regular sorting / pagination has been added to the results.

There is some work still to be done here, such as switching to use the already-provisioned Elasticsearch rather than querying over the database directly with a `like` statement for keyword matching. `find_by_sql` is currently being used as Kaminari errors out using regular Active Record methods for querying (this is because it's trying to compute a count on an aggregated `group by` query).

The main incentive for getting this work done has been as a deadline for a design crit and user research. Now that we've hit this deadline we should go back and make the above changes.