### PR TITLE
Wire-up data to all pages

### DIFF
--- a/app/controllers/number_of_mentions_controller.rb
+++ b/app/controllers/number_of_mentions_controller.rb
@@ -1,15 +1,7 @@
 class NumberOfMentionsController < ApplicationController
   def show
     @phrase = Phrase.find(params[:id])
-    @total_mentions = 127530
-    @mentions_by_day = [
-      { date: '03/04', mentions: '27632' },
-      { date: '04/04', mentions: '25055' },
-      { date: '05/04', mentions: '25602' },
-      { date: '06/04', mentions: '26051' },
-      { date: '07/04', mentions: '25437' },
-      { date: '08/04', mentions: '13006' },
-      { date: '09/04', mentions: '9991' }
-    ]
+    @mentions = SurveyAnswer.find_by_sql(['select date(s.started_at) as date, count(m.id) as total_mentions from survey_phrases m join phrases p on p.id = m.phrase_id join survey_answers sa on sa.id = m.survey_answer_id join surveys s on s.id = sa.survey_id where p.id = ? group by(date(s.started_at)) limit 10;', @phrase.id])
+    @total_mentions = @mentions.inject(0){|sum, mention| sum + mention.total_mentions}
   end
 end

--- a/app/controllers/pages_visited_controller.rb
+++ b/app/controllers/pages_visited_controller.rb
@@ -7,7 +7,7 @@ class PagesVisitedController < ApplicationController
 private
 
   def unique_visitors_by_page
-    Page.find_by_sql("select pages.id, pages.base_path, count(distinct(pv.visit_id)) as unique_visitors from survey_phrases m join phrases on phrases.id = m.phrase_id join survey_answers sa on sa.id = m.survey_answer_id join surveys s on s.id = sa.survey_id join visits v on v.visitor_id = s.visitor_id join page_visits pv on pv.visit_id = v.id join pages on pages.id = pv.page_id where phrases.id = 5 group by (pages.id) order by #{search_params[:sort_key]} #{search_params[:sort_direction]};")
+    Page.find_by_sql("select pages.id, pages.base_path, count(distinct(pv.visit_id)) as unique_visitors from survey_phrases m join phrases on phrases.id = m.phrase_id join survey_answers sa on sa.id = m.survey_answer_id join surveys s on s.id = sa.survey_id join visits v on v.visitor_id = s.visitor_id join page_visits pv on pv.visit_id = v.id join pages on pages.id = pv.page_id where phrases.id = #{@phrase.id} group by (pages.id) order by #{search_params[:sort_key]} #{search_params[:sort_direction]};")
   end
 
   def search_params

--- a/app/controllers/pages_visited_controller.rb
+++ b/app/controllers/pages_visited_controller.rb
@@ -1,6 +1,31 @@
 class PagesVisitedController < ApplicationController
   def show
     @phrase = Phrase.find(params[:id])
-    @unique_visitors_by_page = Page.find_by_sql('select pages.*, count(distinct(page_visits.visit_id)) as unique_visitors from pages join page_visits on page_visits.page_id = pages.id group by pages.id order by unique_visitors desc')
+    @presenter = PagesVisitedPresenter.new(unique_visitors_by_page, search_params)
+  end
+
+private
+
+  def unique_visitors_by_page
+    Page.find_by_sql("select pages.*, count(distinct(page_visits.visit_id)) as unique_visitors from pages join page_visits on page_visits.page_id = pages.id group by pages.id order by #{search_params[:sort_key]} #{search_params[:sort_direction]}")
+  end
+
+  def search_params
+    @search_params ||= begin
+      sort_keys = %w(base_path unique_visitors)
+
+      defaults = {
+        page: 1
+      }.merge(
+        params.permit(
+          :page,
+        ).to_h.symbolize_keys
+      )
+
+      defaults[:sort_key] = sort_keys.include?(params[:sort_key]) ? params[:sort_key] : 'unique_visitors'
+      defaults[:sort_direction] = params[:sort_direction] == 'asc' ? :asc : :desc
+
+      defaults
+    end
   end
 end

--- a/app/controllers/pages_visited_controller.rb
+++ b/app/controllers/pages_visited_controller.rb
@@ -7,7 +7,7 @@ class PagesVisitedController < ApplicationController
 private
 
   def unique_visitors_by_page
-    Page.find_by_sql("select pages.*, count(distinct(page_visits.visit_id)) as unique_visitors from pages join page_visits on page_visits.page_id = pages.id group by pages.id order by #{search_params[:sort_key]} #{search_params[:sort_direction]}")
+    Page.find_by_sql("select pages.id, pages.base_path, count(distinct(pv.visit_id)) as unique_visitors from survey_phrases m join phrases on phrases.id = m.phrase_id join survey_answers sa on sa.id = m.survey_answer_id join surveys s on s.id = sa.survey_id join visits v on v.visitor_id = s.visitor_id join page_visits pv on pv.visit_id = v.id join pages on pages.id = pv.page_id where phrases.id = 5 group by (pages.id) order by #{search_params[:sort_key]} #{search_params[:sort_direction]};")
   end
 
   def search_params

--- a/app/controllers/phrase_controller.rb
+++ b/app/controllers/phrase_controller.rb
@@ -1,26 +1,24 @@
 class PhraseController < ApplicationController
   def show
     @phrase = Phrase.find(params[:id])
-    @pages_visited = Page.limit(10)
     @devices_used = [
       { device_type: 'Desktop', percentage_use: 0.35 },
       { device_type: 'Mobile', percentage_use: 0.6 },
       { device_type: 'Tablet', percentage_use: 0.04 }
     ]
-    @mentions = [
-      'My passport has been mislaid by the Pakistan High Commission. I sent it there to get a visa to visit Pakistan. Now they are asking for my passport number How can I find out my passport number, as I have asthma, if I do not have the passport in my possession?',
-      'My passport has been mislaid by the Pakistan High Commission. I sent it there to get a visa to visit Pakistan. Now they are asking for my passport number How can I find out my passport number, as I have asthma, if I do not have the passport in my possession?',
-      'My passport has been mislaid by the Pakistan High Commission. I sent it there to get a visa to visit Pakistan. Now they are asking for my passport number How can I find out my passport number, as I have asthma, if I do not have the passport in my possession?'
-    ]
-    @total_mentions = 127530
-    @mentions_by_day = {
-      '03/04' => '27632',
-      '04/04' => '25055',
-      '05/04' => '25602',
-      '06/04' => '26051',
-      '07/04' => '25437',
-      '08/04' => '13006',
-      '09/04' => '9991'
-    }
+
+    @pages_visited = pages_visited
+    @mentions = mentions
+    @total_mentions = @mentions.inject(0){|sum, mention| sum + mention.total_mentions}
+  end
+
+private
+
+  def pages_visited
+    Page.find_by_sql('select pages.id, pages.base_path, count(pv.visit_id) as total_pageviews from survey_phrases m join phrases on phrases.id = m.phrase_id join survey_answers sa on sa.id = m.survey_answer_id join surveys s on s.id = sa.survey_id join visits v on v.visitor_id = s.visitor_id join page_visits pv on pv.visit_id = v.id join pages on pages.id = pv.page_id where phrases.id = 5 group by (pages.id) order by total_pageviews desc;')
+  end
+
+  def mentions
+    SurveyAnswer.find_by_sql(['select date(s.started_at) as date, count(m.id) as total_mentions from survey_phrases m join phrases p on p.id = m.phrase_id join survey_answers sa on sa.id = m.survey_answer_id join surveys s on s.id = sa.survey_id where p.id = ? group by(date(s.started_at)) limit 10;', @phrase.id])
   end
 end

--- a/app/controllers/phrase_controller.rb
+++ b/app/controllers/phrase_controller.rb
@@ -10,6 +10,7 @@ class PhraseController < ApplicationController
     @pages_visited = pages_visited
     @mentions = mentions
     @total_mentions = @mentions.inject(0){|sum, mention| sum + mention.total_mentions}
+    @survey_answers_containing_phrase = SurveyAnswer.find_by_sql(["select * from survey_answers sa join questions q on q.id = sa.question_id join survey_phrases sp on sp.survey_answer_id = sa.id join phrases p on p.id = sp.phrase_id where p.id = ? and q.question_number = 3 and sa.answer not like '-' limit 10", "#{@phrase.id}"])
   end
 
 private

--- a/app/controllers/phrase_controller.rb
+++ b/app/controllers/phrase_controller.rb
@@ -15,7 +15,7 @@ class PhraseController < ApplicationController
 private
 
   def pages_visited
-    Page.find_by_sql('select pages.id, pages.base_path, count(pv.visit_id) as total_pageviews from survey_phrases m join phrases on phrases.id = m.phrase_id join survey_answers sa on sa.id = m.survey_answer_id join surveys s on s.id = sa.survey_id join visits v on v.visitor_id = s.visitor_id join page_visits pv on pv.visit_id = v.id join pages on pages.id = pv.page_id where phrases.id = 5 group by (pages.id) order by total_pageviews desc;')
+    Page.find_by_sql("select pages.id, pages.base_path, count(pv.visit_id) as total_pageviews from survey_phrases m join phrases on phrases.id = m.phrase_id join survey_answers sa on sa.id = m.survey_answer_id join surveys s on s.id = sa.survey_id join visits v on v.visitor_id = s.visitor_id join page_visits pv on pv.visit_id = v.id join pages on pages.id = pv.page_id where phrases.id = #{@phrase.id} group by (pages.id) order by total_pageviews desc;")
   end
 
   def mentions

--- a/app/controllers/trending_controller.rb
+++ b/app/controllers/trending_controller.rb
@@ -13,7 +13,7 @@ private
   end
 
   def trending_phrases
-    Phrase.limit(10)
+    Phrase.find_by_sql('select count(m.phrase_id) as mentions, phrases.id, phrases.phrase_text from phrases join survey_phrases m on m.phrase_id = phrases.id join survey_answers sa on sa.id = m.survey_answer_id join surveys s on s.id = sa.survey_id group by (m.phrase_id, phrases.id, phrases.phrase_text) order by mentions desc limit 10')
   end
 
   def trending_tags

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,4 +2,11 @@ module ApplicationHelper
   def format_datetime(datetime)
     datetime.strftime("%d-%m-%y at %H:%M")
   end
+
+  def map_mentions_data_to_chart(mentions_data)
+    mentions_data.each_with_object({}) do |m, hash|
+      date = m.date.strftime('%-d %b')
+      hash[date] = m.total_mentions
+    end
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,11 +2,4 @@ module ApplicationHelper
   def format_datetime(datetime)
     datetime.strftime("%d-%m-%y at %H:%M")
   end
-
-  def map_mentions_data_to_chart(mentions_data)
-    mentions_data.each_with_object({}) do |m, hash|
-      date = DateTime.parse(m.date).strftime('%-d %b')
-      hash[date] = m.total_mentions
-    end
-  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,4 +2,11 @@ module ApplicationHelper
   def format_datetime(datetime)
     datetime.strftime("%d-%m-%y at %H:%M")
   end
+
+  def map_mentions_data_to_chart(mentions_data)
+    mentions_data.each_with_object({}) do |m, hash|
+      date = DateTime.parse(m.date).strftime('%-d %b')
+      hash[date] = m.total_mentions
+    end
+  end
 end

--- a/app/helpers/number_of_mentions_helper.rb
+++ b/app/helpers/number_of_mentions_helper.rb
@@ -1,23 +1,13 @@
-require 'time'
 require 'active_support'
 require 'active_support/core_ext/integer/inflections'
 
 module NumberOfMentionsHelper
   def map_mentions_data_to_table(data)
     data.map do |row|
-      date = Time.parse(row.date)
-
       [
-        { text: date.strftime("#{date.day.ordinalize} %b %Y") },
+        { text: row.date.strftime("#{row.date.day.ordinalize} %b %Y") },
         { text: row.total_mentions, format: 'numeric' }
       ]
-    end
-  end
-
-  def map_mentions_data_to_chart(data)
-    data.each_with_object({}) do |m, hash|
-      date = DateTime.parse(m.date).strftime('%-d %b')
-      hash[date] = m.total_mentions
     end
   end
 end

--- a/app/helpers/number_of_mentions_helper.rb
+++ b/app/helpers/number_of_mentions_helper.rb
@@ -1,14 +1,23 @@
+require 'time'
+require 'active_support'
+require 'active_support/core_ext/integer/inflections'
+
 module NumberOfMentionsHelper
   def map_mentions_data_to_table(data)
     data.map do |row|
+      date = Time.parse(row.date)
+
       [
-        { text: row[:date] },
-        { text: row[:mentions], format: 'numeric' }
+        { text: date.strftime("#{date.day.ordinalize} %b %Y") },
+        { text: row.total_mentions, format: 'numeric' }
       ]
     end
   end
 
   def map_mentions_data_to_chart(data)
-    data.each_with_object({}){|d, hash| hash[d[:date]] = d[:mentions] }
+    data.each_with_object({}) do |m, hash|
+      date = DateTime.parse(m.date).strftime('%-d %b')
+      hash[date] = m.total_mentions
+    end
   end
 end

--- a/app/helpers/pages_visited_helper.rb
+++ b/app/helpers/pages_visited_helper.rb
@@ -1,4 +1,30 @@
 module PagesVisitedHelper
+  def page_visited_table_headers
+    column_map = {
+      "base_path" => {
+        text: "Page title",
+        href: "#{pages_visited_path(@phrase)}?sort_key=base_path&sort_direction=asc"
+      },
+      "unique_visitors" => {
+        text: "Number of unique visitors",
+        format: "numeric",
+        href: "#{pages_visited_path(@phrase)}?sort_key=unique_visitors&sort_direction=asc"
+      }
+    }
+
+    unless @presenter.sorting.sort_key.blank?
+      dir = @presenter.sorting.sort_direction == :asc ? :desc : :asc
+      column_map[@presenter.sorting.sort_key].merge!(
+        {
+          sort_direction: sort_directions[@presenter.sorting.sort_direction],
+          href: "#{pages_visited_path(@phrase)}?sort_key=#{@presenter.sorting.sort_key}&sort_direction=#{dir}&page=#{@presenter.pagination.page}"
+        }
+      )
+    end
+
+    column_map.values
+  end
+
   def map_pages_visited_data_to_table(data)
     data.map do |row|
       [

--- a/app/helpers/phrase_helper.rb
+++ b/app/helpers/phrase_helper.rb
@@ -7,4 +7,11 @@ module PhraseHelper
       ]
     end
   end
+
+  def map_mentions_data_to_chart(mentions_data)
+    mentions_data.each_with_object({}) do |m, hash|
+      date = DateTime.parse(m.date).strftime('%-d %b')
+      hash[date] = m.total_mentions
+    end
+  end
 end

--- a/app/helpers/phrase_helper.rb
+++ b/app/helpers/phrase_helper.rb
@@ -7,11 +7,4 @@ module PhraseHelper
       ]
     end
   end
-
-  def map_mentions_data_to_chart(mentions_data)
-    mentions_data.each_with_object({}) do |m, hash|
-      date = DateTime.parse(m.date).strftime('%-d %b')
-      hash[date] = m.total_mentions
-    end
-  end
 end

--- a/app/presenters/pages_visited_presenter.rb
+++ b/app/presenters/pages_visited_presenter.rb
@@ -1,0 +1,11 @@
+class PagesVisitedPresenter
+  attr_reader :pagination, :sorting, :search_params, :unique_visitors_by_page
+
+  def initialize(items, search_params)
+    @search_params = search_params
+    @pagination = PaginationPresenter.new(page: search_params[:page], total_items: items.count)
+    @sorting = SortPresenter.new(sort_key: search_params[:sort_key], sort_direction: search_params[:sort_direction])
+
+    @unique_visitors_by_page = pagination.paginate(items)
+  end
+end

--- a/app/views/number_of_mentions/show.html.erb
+++ b/app/views/number_of_mentions/show.html.erb
@@ -17,7 +17,7 @@
       <p class="govuk-body statistic-total"><%= number_with_delimiter(@total_mentions) %></p>
     </div>
 
-    <%= line_chart map_mentions_data_to_chart(@mentions_by_day), library: { curveType: 'none' }, defer: true %>
+    <%= line_chart map_mentions_data_to_chart(@mentions), library: { curveType: 'none' }, defer: true %>
   </div>
 </div>
 
@@ -34,7 +34,7 @@
                   format: "numeric"
               }
           ],
-          rows: map_mentions_data_to_table(@mentions_by_day)
+          rows: map_mentions_data_to_table(@mentions)
       } %>
     </div>
   </div>

--- a/app/views/pages_visited/show.html.erb
+++ b/app/views/pages_visited/show.html.erb
@@ -13,16 +13,8 @@
   <div class="govuk-grid-column-two-thirds">
     <div class="table-group">
       <%= render "govuk_publishing_components/components/table", {
-          head: [
-              {
-                  text: "Page title"
-              },
-              {
-                  text: "Number of unique visitors",
-                  format: "numeric"
-              }
-          ],
-          rows: map_pages_visited_data_to_table(@unique_visitors_by_page)
+          head: page_visited_table_headers,
+          rows: map_pages_visited_data_to_table(@presenter.unique_visitors_by_page)
       } %>
     </div>
   </div>

--- a/app/views/phrase/show.html.erb
+++ b/app/views/phrase/show.html.erb
@@ -65,9 +65,9 @@
         <span class="govuk-caption-m">In the past 7 days</span>
       </h2>
 
-      <% @mentions.each do |mention| %>
+      <% @survey_answers_containing_phrase.each do |sa| %>
         <%= render "govuk_publishing_components/components/inset_text", {
-            text: mention
+            text: sa.answer
         } %>
       <% end %>
     </div>

--- a/app/views/phrase/show.html.erb
+++ b/app/views/phrase/show.html.erb
@@ -18,7 +18,7 @@
       <p class="govuk-body statistic-total"><%= number_with_delimiter(@total_mentions) %></p>
     </div>
 
-    <%= line_chart @mentions_by_day, library: { curveType: 'none' }, defer: true %>
+    <%= line_chart map_mentions_data_to_chart(@mentions), library: { curveType: 'none' }, defer: true %>
 
   </div>
 </div>


### PR DESCRIPTION
This PR wires-up data to all new pages in the app for the MVP v2 iteration. There are some future refactorings to be done, such as changing all queries to use ActiveRecord methods rather than simply `find_by_sql`, however in the interests of time and deadlines, the emphasis has been to go with an approach which works.

As mentioned in one of the commits, the schema right now is unable to identify a survey with the _actual_ pages visited as part of that survey. This means that when we get the top pages associated with survey responses containing a particular phrase, we're most likely getting an inaccurate result because we're counting all page visits by the user across all surveys rather than a subset of their surveys. This will be fixed with an iteration to the schema.

It also updates the .gitignore file to include files in the `.idea` directory (as used by RubyMine).