### PR TITLE
Add phrase highlighting

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -32,3 +32,7 @@
   font-size: 36px;
   font-weight: bold;
 }
+
+.phrase-highlight {
+  font-weight: bold;
+}

--- a/app/helpers/phrase_usage_helper.rb
+++ b/app/helpers/phrase_usage_helper.rb
@@ -1,2 +1,5 @@
 module PhraseUsageHelper
+  def highlighted_survey_answer_html(survey_answer, phrase)
+    survey_answer.gsub(/(#{phrase})/i){ |match| "<span class='phrase-highlight'>#{match}</span>" }.html_safe
+  end
 end

--- a/app/views/phrase/show.html.erb
+++ b/app/views/phrase/show.html.erb
@@ -67,7 +67,7 @@
 
       <% @survey_answers_containing_phrase.each do |sa| %>
         <%= render "govuk_publishing_components/components/inset_text", {
-            text: sa.answer
+            text: highlighted_survey_answer_html(sa.answer, @phrase.phrase_text)
         } %>
       <% end %>
     </div>

--- a/app/views/phrase_usage/show.html.erb
+++ b/app/views/phrase_usage/show.html.erb
@@ -16,7 +16,7 @@
 
       <% @survey_answers_containing_phrase.each do |answer| %>
         <%= render "govuk_publishing_components/components/inset_text", {
-            text: answer.answer
+            text: highlighted_survey_answer_html(answer.answer, @phrase.phrase_text)
         } %>
       <% end %>
     </div>


### PR DESCRIPTION
This PR adds phrase highlighting to the phrase and phrase usage pages, so that users can easily see how a given phrase has been used in the context of survey answers.