### PR TITLE
Use aggregate data for phrase mentions in charts and tables

### DIFF
--- a/app/controllers/number_of_mentions_controller.rb
+++ b/app/controllers/number_of_mentions_controller.rb
@@ -1,7 +1,13 @@
 class NumberOfMentionsController < ApplicationController
   def show
     @phrase = Phrase.find(params[:id])
-    @mentions = SurveyAnswer.find_by_sql(['select date(s.started_at) as date, count(m.id) as total_mentions from survey_phrases m join phrases p on p.id = m.phrase_id join survey_answers sa on sa.id = m.survey_answer_id join surveys s on s.id = sa.survey_id where p.id = ? group by(date(s.started_at)) limit 10;', @phrase.id])
-    @total_mentions = @mentions.inject(0){|sum, mention| sum + mention.total_mentions}
+    @mentions = mentions
+  end
+
+private
+
+  def mentions
+    SurveyPhrase.mentions_by_date_range_for_phrase(@phrase, Date.new(2020, 4, 1), Date.new(2020, 4, 7))
+      .sort_by{ |date, _| date }
   end
 end

--- a/app/controllers/phrase_controller.rb
+++ b/app/controllers/phrase_controller.rb
@@ -9,7 +9,6 @@ class PhraseController < ApplicationController
 
     @pages_visited = pages_visited
     @mentions = mentions
-    @total_mentions = @mentions.inject(0){|sum, mention| sum + mention.total_mentions}
     @survey_answers_containing_phrase = SurveyAnswer.find_by_sql(["select * from survey_answers sa join questions q on q.id = sa.question_id join survey_phrases sp on sp.survey_answer_id = sa.id join phrases p on p.id = sp.phrase_id where p.id = ? and q.question_number = 3 and sa.answer not like '-' limit 10", "#{@phrase.id}"])
   end
 
@@ -20,6 +19,9 @@ private
   end
 
   def mentions
-    SurveyAnswer.find_by_sql(['select date(s.started_at) as date, count(m.id) as total_mentions from survey_phrases m join phrases p on p.id = m.phrase_id join survey_answers sa on sa.id = m.survey_answer_id join surveys s on s.id = sa.survey_id where p.id = ? group by(date(s.started_at)) limit 10;', @phrase.id])
+    SurveyPhrase
+      .mentions_by_date_range_for_phrase(@phrase, Date.new(2020, 4, 1), Date.new(2020, 4, 7))
+      .sort_by{ |date, _| date }
+      .to_h
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,9 +4,10 @@ module ApplicationHelper
   end
 
   def map_mentions_data_to_chart(mentions_data)
-    mentions_data.each_with_object({}) do |m, hash|
-      date = m.date.strftime('%-d %b')
-      hash[date] = m.total_mentions
-    end
+    mentions_data.each_with_object({}){|(date, total_mentions), hash| hash[date.strftime('%-d %b')] = total_mentions }
+  end
+
+  def total_mentions(mentions_data)
+    mentions_data.sum {|_, daily_mentions| daily_mentions }
   end
 end

--- a/app/helpers/number_of_mentions_helper.rb
+++ b/app/helpers/number_of_mentions_helper.rb
@@ -3,10 +3,10 @@ require 'active_support/core_ext/integer/inflections'
 
 module NumberOfMentionsHelper
   def map_mentions_data_to_table(data)
-    data.map do |row|
+    data.map do |date, total_mentions|
       [
-        { text: row.date.strftime("#{row.date.day.ordinalize} %b %Y") },
-        { text: row.total_mentions, format: 'numeric' }
+        { text: date.strftime("#{date.day.ordinalize} %b %Y") },
+        { text: total_mentions, format: 'numeric' }
       ]
     end
   end

--- a/app/models/survey_phrase.rb
+++ b/app/models/survey_phrase.rb
@@ -1,4 +1,25 @@
 class SurveyPhrase < ApplicationRecord
   belongs_to :phrase
   belongs_to :survey_answer
+
+  def self.mentions_by_date_range_for_phrase(phrase, start_date, end_date)
+    date_range = start_date..end_date
+
+    mentions = SurveyPhrase.joins(:phrase, survey_answer: :survey)
+     .where(phrase: phrase, 'surveys.started_at' => date_range)
+     .group('date(surveys.started_at)')
+     .order('date(surveys.started_at) asc')
+     .limit(10)
+     .pluck('date(surveys.started_at)', 'count(survey_phrases.id)')
+
+    present_dates = mentions.map { |date, _| date }
+
+    date_range.each do |date|
+      unless present_dates.include?(date)
+        mentions << [date, 0]
+      end
+    end
+
+    mentions
+  end
 end

--- a/app/views/number_of_mentions/show.html.erb
+++ b/app/views/number_of_mentions/show.html.erb
@@ -14,7 +14,7 @@
   <div class="govuk-grid-column-two-thirds">
     <div class="chart-group">
       <span class="govuk-caption-m">In the past 7 days</span>
-      <p class="govuk-body statistic-total"><%= number_with_delimiter(@total_mentions) %></p>
+      <p class="govuk-body statistic-total"><%= number_with_delimiter(total_mentions(@mentions)) %></p>
     </div>
 
     <%= line_chart map_mentions_data_to_chart(@mentions), library: { curveType: 'none' }, defer: true %>

--- a/app/views/phrase/show.html.erb
+++ b/app/views/phrase/show.html.erb
@@ -15,7 +15,7 @@
         <span class="govuk-caption-m">In the past 7 days</span>
       </h2>
 
-      <p class="govuk-body statistic-total"><%= number_with_delimiter(@total_mentions) %></p>
+      <p class="govuk-body statistic-total"><%= number_with_delimiter(total_mentions(@mentions)) %></p>
     </div>
 
     <%= line_chart map_mentions_data_to_chart(@mentions), library: { curveType: 'none' }, defer: true %>


### PR DESCRIPTION
This PR updates the chart and table data for mentions of a particular phrase to use aggregated values and to be consistent with each other.

Date range is hard-coded at the moment for the initial set of test data, and until we have designs for how we're going to incorporate date range picking.