### PR TITLE
Add Google Tag Manager component

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,13 @@
 <% content_for :head do %>
   <%= javascript_include_tag "https://www.gstatic.com/charts/loader.js" %>
+
+  <% if ENV["GOOGLE_TAG_MANAGER_ID"] %>
+    <%= render "govuk_publishing_components/components/google_tag_manager_script", {
+      gtm_id: ENV["GOOGLE_TAG_MANAGER_ID"],
+      gtm_auth: ENV["GOOGLE_TAG_MANAGER_AUTH"],
+      gtm_preview: ENV["GOOGLE_TAG_MANAGER_PREVIEW"],
+    } %>
+  <% end %>
 <% end %>
 
 <%= render 'govuk_publishing_components/components/layout_for_admin',


### PR DESCRIPTION
This PR adds the Google Tag Manager component to the explorer, so that we can understand user engagement with the app when we release the MVP.