### PR TITLE
Add device data to phrase page

### DIFF
--- a/app/controllers/phrase_controller.rb
+++ b/app/controllers/phrase_controller.rb
@@ -10,7 +10,8 @@ class PhraseController < ApplicationController
 private
 
   def devices
-    device_totals = Device.breakdown_by_date_range(Date.new(2020, 4, 1), Date.new(20202, 4, 7))
+    device_totals = Device.breakdown_by_date_range_for_phrase(@phrase, Date.new(2020, 4, 1), Date.new(2020, 4, 7))
+
     all_device_hits_total = device_totals.sum { |_, total| total }
 
     device_totals.map do |device_name, device_total|

--- a/app/controllers/phrase_controller.rb
+++ b/app/controllers/phrase_controller.rb
@@ -1,18 +1,22 @@
 class PhraseController < ApplicationController
   def show
     @phrase = Phrase.find(params[:id])
-    @devices_used = [
-      { device_type: 'Desktop', percentage_use: 0.35 },
-      { device_type: 'Mobile', percentage_use: 0.6 },
-      { device_type: 'Tablet', percentage_use: 0.04 }
-    ]
-
+    @devices = devices
     @pages_visited = pages_visited
     @mentions = mentions
     @survey_answers_containing_phrase = SurveyAnswer.find_by_sql(["select * from survey_answers sa join questions q on q.id = sa.question_id join survey_phrases sp on sp.survey_answer_id = sa.id join phrases p on p.id = sp.phrase_id where p.id = ? and q.question_number = 3 and sa.answer not like '-' limit 10", "#{@phrase.id}"])
   end
 
 private
+
+  def devices
+    device_totals = Device.breakdown_by_date_range(Date.new(2020, 4, 1), Date.new(20202, 4, 7))
+    all_device_hits_total = device_totals.sum { |_, total| total }
+
+    device_totals.map do |device_name, device_total|
+      { device_type: device_name, percentage_use: (device_total.to_f / all_device_hits_total) }
+    end
+  end
 
   def pages_visited
     Page.find_by_sql("select pages.id, pages.base_path, count(pv.visit_id) as total_pageviews from survey_phrases m join phrases on phrases.id = m.phrase_id join survey_answers sa on sa.id = m.survey_answer_id join surveys s on s.id = sa.survey_id join visits v on v.visitor_id = s.visitor_id join page_visits pv on pv.visit_id = v.id join pages on pages.id = pv.page_id where phrases.id = #{@phrase.id} group by (pages.id) order by total_pageviews desc;")

--- a/app/helpers/phrase_helper.rb
+++ b/app/helpers/phrase_helper.rb
@@ -1,5 +1,5 @@
 module PhraseHelper
-  def map_device_data(device_data)
+  def map_device_data_to_table(device_data)
     device_data.map do |row|
       [
         { text: row[:device_type] },

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -1,11 +1,13 @@
 class Device < ApplicationRecord
   has_many :visits
 
-  def self.breakdown_by_date_range(start_date, end_date)
-    device_totals = Device
-      .find_by_sql("select devices.id, devices.name, count(v.device_id) as total from survey_phrases m join phrases on phrases.id = m.phrase_id join survey_answers sa on sa.id = m.survey_answer_id join surveys s on s.id = sa.survey_id join visits v on v.visitor_id = s.visitor_id join devices on devices.id = v.device_id group by (devices.id) order by devices.id;")
-      .pluck(:name, :total)
+  def self.breakdown_by_date_range_for_phrase(phrase, start_date, end_date)
+    date_range = start_date..end_date
 
-    device_totals
+    Device.joins(visits: [{ visitor: [{ surveys: [{ survey_answers: [{ survey_phrases: :phrase }] }] }] }])
+      .where('phrases.id' => phrase.id, 'surveys.started_at' => date_range)
+      .group('devices.id')
+      .order('devices.id')
+      .pluck('devices.name', 'count(visits.device_id)')
   end
 end

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -1,3 +1,11 @@
 class Device < ApplicationRecord
   has_many :visits
+
+  def self.breakdown_by_date_range(start_date, end_date)
+    device_totals = Device
+      .find_by_sql("select devices.id, devices.name, count(v.device_id) as total from survey_phrases m join phrases on phrases.id = m.phrase_id join survey_answers sa on sa.id = m.survey_answer_id join surveys s on s.id = sa.survey_id join visits v on v.visitor_id = s.visitor_id join devices on devices.id = v.device_id group by (devices.id) order by devices.id;")
+      .pluck(:name, :total)
+
+    device_totals
+  end
 end

--- a/app/views/phrase/show.html.erb
+++ b/app/views/phrase/show.html.erb
@@ -37,7 +37,7 @@
   <div class="govuk-grid-column-two-thirds">
     <div class="table-group">
       <h2 class="govuk-heading-m">
-        <%= link_to "Devices used", "/devices" %>
+        Devices used
         <span class="govuk-caption-m">In the past 7 days</span>
       </h2>
 
@@ -51,7 +51,7 @@
                   format: "numeric"
               }
           ],
-          rows: map_device_data(@devices_used)
+          rows: map_device_data_to_table(@devices)
       } %>
     </div>
   </div>


### PR DESCRIPTION
This PR adds device data to the phrase page, currently for a placeholder period of April 1st - April 7th 2020. This data has the same caveat as the top page data for a particular phrase, where we will include all data related to a particular visitor because of a lack of a more specific join between the `surveys` and `visits` tables.