### PR TITLE
Add pagination to page mentions and page phrases pages

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -40,3 +40,37 @@ a {
 .phrase-highlight {
   font-weight: bold;
 }
+
+.equal-width-table .govuk-table {
+  outline: none !important;
+}
+
+.equal-width-table td {
+  width: 50%;
+}
+
+.equal-width-table thead tr {
+  border-bottom: 1px solid #626a6e;
+}
+
+.equal-width-table thead th {
+  background-color: transparent !important;
+  text-decoration: underline;
+  font-weight: bold;
+}
+
+.equal-width-table tbody tr {
+  border-bottom: 1px solid #626a6e;
+}
+
+.equal-width-table thead tr:hover, .equal-width-table tbody tr:hover {
+  background-color: transparent !important;
+}
+
+.equal-width-table tbody tr:nth-child(even) {
+  background-color: transparent !important;
+}
+
+.equal-width-table .govuk-table__header--active a {
+  color: #1d70b8 !important;
+}

--- a/app/controllers/phrase_controller.rb
+++ b/app/controllers/phrase_controller.rb
@@ -4,7 +4,7 @@ class PhraseController < ApplicationController
     @devices = devices
     @pages_visited = pages_visited
     @mentions = mentions
-    @survey_answers_containing_phrase = SurveyAnswer.find_by_sql(["select * from survey_answers sa join questions q on q.id = sa.question_id join survey_phrases sp on sp.survey_answer_id = sa.id join phrases p on p.id = sp.phrase_id where p.id = ? and q.question_number = 3 and sa.answer not like '-' limit 10", "#{@phrase.id}"])
+    @survey_answers_containing_phrase = SurveyAnswer.find_by_sql(["select * from survey_answers sa join questions q on q.id = sa.question_id join survey_phrases sp on sp.survey_answer_id = sa.id join phrases p on p.id = sp.phrase_id where p.id = ? and q.question_number = 3 and sa.answer not like '-' limit 3", "#{@phrase.id}"])
   end
 
 private
@@ -20,7 +20,7 @@ private
   end
 
   def pages_visited
-    Page.find_by_sql("select pages.id, pages.base_path, count(pv.visit_id) as total_pageviews from survey_phrases m join phrases on phrases.id = m.phrase_id join survey_answers sa on sa.id = m.survey_answer_id join surveys s on s.id = sa.survey_id join visits v on v.visitor_id = s.visitor_id join page_visits pv on pv.visit_id = v.id join pages on pages.id = pv.page_id where phrases.id = #{@phrase.id} group by (pages.id) order by total_pageviews desc;")
+    Page.find_by_sql("select pages.id, pages.base_path, count(pv.visit_id) as total_pageviews from survey_phrases m join phrases on phrases.id = m.phrase_id join survey_answers sa on sa.id = m.survey_answer_id join surveys s on s.id = sa.survey_id join visits v on v.visitor_id = s.visitor_id join page_visits pv on pv.visit_id = v.id join pages on pages.id = pv.page_id where phrases.id = #{@phrase.id} group by (pages.id) order by total_pageviews desc limit 10;")
   end
 
   def mentions

--- a/app/controllers/phrase_controller.rb
+++ b/app/controllers/phrase_controller.rb
@@ -20,7 +20,7 @@ private
   end
 
   def pages_visited
-    Page.find_by_sql("select pages.id, pages.base_path, count(pv.visit_id) as total_pageviews from survey_phrases m join phrases on phrases.id = m.phrase_id join survey_answers sa on sa.id = m.survey_answer_id join surveys s on s.id = sa.survey_id join visits v on v.visitor_id = s.visitor_id join page_visits pv on pv.visit_id = v.id join pages on pages.id = pv.page_id where phrases.id = #{@phrase.id} group by (pages.id) order by total_pageviews desc limit 10;")
+    Page.find_by_sql("select pages.id, pages.base_path, count(pv.visit_id) as total_pageviews, concat(\'https://www.gov.uk\', pages.base_path) as govuk_link from survey_phrases m join phrases on phrases.id = m.phrase_id join survey_answers sa on sa.id = m.survey_answer_id join surveys s on s.id = sa.survey_id join visits v on v.visitor_id = s.visitor_id join page_visits pv on pv.visit_id = v.id join pages on pages.id = pv.page_id where phrases.id = #{@phrase.id} group by (pages.id) order by total_pageviews desc limit 10;")
   end
 
   def mentions

--- a/app/controllers/phrase_usage_controller.rb
+++ b/app/controllers/phrase_usage_controller.rb
@@ -1,6 +1,22 @@
 class PhraseUsageController < ApplicationController
   def show
     @phrase = Phrase.find(params[:id])
-    @survey_answers_containing_phrase = SurveyAnswer.find_by_sql(["select * from survey_answers sa join questions q on q.id = sa.question_id join survey_phrases sp on sp.survey_answer_id = sa.id join phrases p on p.id = sp.phrase_id where p.id = ? and q.question_number = 3 and sa.answer not like '-' limit 10", "#{params[:id]}"])
+    @presenter = PhraseUsagePresenter.new(survey_answers_containing_phrase, search_params)
+  end
+
+private
+
+  def survey_answers_containing_phrase
+    SurveyAnswer.find_by_sql(["select * from survey_answers sa join questions q on q.id = sa.question_id join survey_phrases sp on sp.survey_answer_id = sa.id join phrases p on p.id = sp.phrase_id where p.id = ? and q.question_number = 3 and sa.answer not like '-' limit 10", "#{params[:id]}"])
+  end
+
+  def search_params
+    @search_params ||= begin
+      { page: 1 }.merge(
+        params.permit(
+          :page,
+        ).to_h.symbolize_keys
+      )
+    end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,4 +10,30 @@ module ApplicationHelper
   def total_mentions(mentions_data)
     mentions_data.sum {|_, daily_mentions| daily_mentions }
   end
+
+  def navigation_links(presenter)
+    links = {}
+
+    if presenter.page > 1
+      links = links.merge(
+        previous_page: {
+          url: path_to_previous_page(presenter.items),
+          title: "Previous page",
+          label: "#{@presenter.page - 1} of #{presenter.total_pages}"
+        }
+      )
+    end
+
+    if presenter.page < presenter.total_pages
+      links = links.merge(
+        next_page: {
+          url: path_to_next_page(presenter.items),
+          title: "Next page",
+          label: "#{presenter.page + 1} of #{presenter.total_pages}"
+        }
+      )
+    end
+
+    links
+  end
 end

--- a/app/helpers/pages_visited_helper.rb
+++ b/app/helpers/pages_visited_helper.rb
@@ -53,8 +53,10 @@ module PagesVisitedHelper
 
   def map_pages_visited_data_to_table(data)
     data.map do |row|
+      link = link_to row[:base_path], "https://www.gov.uk#{row[:base_path]}"
+
       [
-        { text: row[:base_path] },
+        { text: link },
         { text: row[:unique_visitors], format: 'numeric' }
       ]
     end

--- a/app/helpers/pages_visited_helper.rb
+++ b/app/helpers/pages_visited_helper.rb
@@ -1,30 +1,4 @@
 module PagesVisitedHelper
-  def pages_visited_navigation_links
-    links = {}
-
-    if @presenter.pagination.page > 1
-      links = links.merge(
-        previous_page: {
-          url: path_to_previous_page(@presenter.unique_visitors_by_page),
-          title: "Previous page",
-          label: "#{@presenter.pagination.page - 1} of #{@presenter.pagination.total_pages}"
-        }
-      )
-    end
-
-    if @presenter.pagination.page < @presenter.pagination.total_pages
-      links = links.merge(
-        next_page: {
-          url: path_to_next_page(@presenter.unique_visitors_by_page),
-          title: "Next page",
-          label: "#{@presenter.pagination.page + 1} of #{@presenter.pagination.total_pages}"
-        }
-      )
-    end
-
-    links
-  end
-
   def page_visited_table_headers
     column_map = {
       "base_path" => {

--- a/app/helpers/pages_visited_helper.rb
+++ b/app/helpers/pages_visited_helper.rb
@@ -1,4 +1,30 @@
 module PagesVisitedHelper
+  def pages_visited_navigation_links
+    links = {}
+
+    if @presenter.pagination.page > 1
+      links = links.merge(
+        previous_page: {
+          url: path_to_previous_page(@presenter.unique_visitors_by_page),
+          title: "Previous page",
+          label: "#{@presenter.pagination.page - 1} of #{@presenter.pagination.total_pages}"
+        }
+      )
+    end
+
+    if @presenter.pagination.page < @presenter.pagination.total_pages
+      links = links.merge(
+        next_page: {
+          url: path_to_next_page(@presenter.unique_visitors_by_page),
+          title: "Next page",
+          label: "#{@presenter.pagination.page + 1} of #{@presenter.pagination.total_pages}"
+        }
+      )
+    end
+
+    links
+  end
+
   def page_visited_table_headers
     column_map = {
       "base_path" => {
@@ -8,7 +34,7 @@ module PagesVisitedHelper
       "unique_visitors" => {
         text: "Number of unique visitors",
         format: "numeric",
-        href: "#{pages_visited_path(@phrase)}?sort_key=unique_visitors&sort_direction=asc"
+        href: "#{pages_visited_path(@phrase)}?sort_key=unique_visitors&sort_direction=asc",
       }
     }
 

--- a/app/helpers/phrase_usage_helper.rb
+++ b/app/helpers/phrase_usage_helper.rb
@@ -2,30 +2,4 @@ module PhraseUsageHelper
   def highlighted_survey_answer_html(survey_answer, phrase)
     survey_answer.gsub(/(#{phrase})/i){ |match| "<span class='phrase-highlight'>#{match}</span>" }.html_safe
   end
-
-  def phrase_usage_navigation_links
-    links = {}
-
-    if @presenter.pagination.page > 1
-      links = links.merge(
-        previous_page: {
-          url: path_to_previous_page(@presenter.survey_answers_containing_phrase),
-          title: "Previous page",
-          label: "#{@presenter.pagination.page - 1} of #{@presenter.pagination.total_pages}"
-        }
-      )
-    end
-
-    if @presenter.pagination.page < @presenter.pagination.total_pages
-      links = links.merge(
-        next_page: {
-          url: path_to_next_page(@presenter.survey_answers_containing_phrase),
-          title: "Next page",
-          label: "#{@presenter.pagination.page + 1} of #{@presenter.pagination.total_pages}"
-        }
-      )
-    end
-
-    links
-  end
 end

--- a/app/helpers/phrase_usage_helper.rb
+++ b/app/helpers/phrase_usage_helper.rb
@@ -2,4 +2,30 @@ module PhraseUsageHelper
   def highlighted_survey_answer_html(survey_answer, phrase)
     survey_answer.gsub(/(#{phrase})/i){ |match| "<span class='phrase-highlight'>#{match}</span>" }.html_safe
   end
+
+  def phrase_usage_navigation_links
+    links = {}
+
+    if @presenter.pagination.page > 1
+      links = links.merge(
+        previous_page: {
+          url: path_to_previous_page(@presenter.survey_answers_containing_phrase),
+          title: "Previous page",
+          label: "#{@presenter.pagination.page - 1} of #{@presenter.pagination.total_pages}"
+        }
+      )
+    end
+
+    if @presenter.pagination.page < @presenter.pagination.total_pages
+      links = links.merge(
+        next_page: {
+          url: path_to_next_page(@presenter.survey_answers_containing_phrase),
+          title: "Next page",
+          label: "#{@presenter.pagination.page + 1} of #{@presenter.pagination.total_pages}"
+        }
+      )
+    end
+
+    links
+  end
 end

--- a/app/helpers/summary_helper.rb
+++ b/app/helpers/summary_helper.rb
@@ -8,32 +8,6 @@ module SummaryHelper
     }
   end
 
-  def navigation_links
-    links = {}
-
-    if @presenter.pagination.page > 1
-      links = links.merge(
-        previous_page: {
-          url: path_to_previous_page(@presenter.content_pages),
-          title: "Previous page",
-          label: "#{@presenter.pagination.page - 1} of #{@presenter.pagination.total_pages}"
-        }
-      )
-    end
-
-    if @presenter.pagination.page < @presenter.pagination.total_pages
-      links = links.merge(
-        next_page: {
-          url: path_to_next_page(@presenter.content_pages),
-          title: "Next page",
-          label: "#{@presenter.pagination.page + 1} of #{@presenter.pagination.total_pages}"
-        }
-      )
-    end
-
-    links
-  end
-
   def get_table_headers
     column_map = {
       "base_path" => {
@@ -67,7 +41,7 @@ module SummaryHelper
 
 
   def map_content_pages_to_table
-    @presenter.content_pages.map do |page|
+    @presenter.items.map do |page|
       link = link_to page.base_path, "/pages/#{page.id}"
 
       [

--- a/app/presenters/pages_visited_presenter.rb
+++ b/app/presenters/pages_visited_presenter.rb
@@ -1,11 +1,12 @@
 class PagesVisitedPresenter
-  attr_reader :pagination, :sorting, :search_params, :unique_visitors_by_page
+  attr_reader :pagination, :sorting, :search_params, :items
+  delegate :page, :total_pages, to: :pagination
 
   def initialize(items, search_params)
     @search_params = search_params
     @pagination = PaginationPresenter.new(page: search_params[:page], total_items: items.count)
     @sorting = SortPresenter.new(sort_key: search_params[:sort_key], sort_direction: search_params[:sort_direction])
 
-    @unique_visitors_by_page = pagination.paginate(items)
+    @items = pagination.paginate(items)
   end
 end

--- a/app/presenters/phrase_usage_presenter.rb
+++ b/app/presenters/phrase_usage_presenter.rb
@@ -1,9 +1,10 @@
 class PhraseUsagePresenter
-  attr_reader :pagination, :search_params, :survey_answers_containing_phrase
+  attr_reader :pagination, :search_params, :items
+  delegate :page, :total_pages, to: :pagination
 
   def initialize(items, search_params)
     @search_params = search_params
     @pagination = PaginationPresenter.new(page: search_params[:page], total_items: items.count)
-    @survey_answers_containing_phrase = pagination.paginate(items)
+    @items = pagination.paginate(items)
   end
 end

--- a/app/presenters/phrase_usage_presenter.rb
+++ b/app/presenters/phrase_usage_presenter.rb
@@ -1,0 +1,9 @@
+class PhraseUsagePresenter
+  attr_reader :pagination, :search_params, :survey_answers_containing_phrase
+
+  def initialize(items, search_params)
+    @search_params = search_params
+    @pagination = PaginationPresenter.new(page: search_params[:page], total_items: items.count)
+    @survey_answers_containing_phrase = pagination.paginate(items)
+  end
+end

--- a/app/presenters/summary_presenter.rb
+++ b/app/presenters/summary_presenter.rb
@@ -1,11 +1,12 @@
 class SummaryPresenter
-  attr_reader :pagination, :sorting, :search_params, :content_pages
+  attr_reader :pagination, :sorting, :search_params, :items
+  delegate :page, :total_pages, :total_items, to: :pagination
 
   def initialize(items, search_params)
     @search_params = search_params
     @pagination = PaginationPresenter.new(page: search_params[:page], total_items: items.count)
     @sorting = SortPresenter.new(sort_key: search_params[:sort_key], sort_direction: search_params[:sort_direction])
 
-    @content_pages = pagination.paginate(items)
+    @items = pagination.paginate(items)
   end
 end

--- a/app/views/number_of_mentions/show.html.erb
+++ b/app/views/number_of_mentions/show.html.erb
@@ -7,15 +7,13 @@
 <span class="govuk-caption-xl"><%= @phrase.phrase_text %></span>
 <h1 class="govuk-heading-xl">Number of mentions</h1>
 
-<p class="govuk-body govuk-!-margin-bottom-7">Last updated 6 April 2020 9:04am</p>
-
 <p class="govuk-body govuk-!-margin-bottom-7">THIS IS PLACEHOLDER TEXT. Users that had at least one mention of
   '<%= @phrase.phrase_text %>' in their user intent survey answers.</p>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <div class="chart-group">
-      <span class="govuk-caption-m">In the past 7 days</span>
+      <span class="govuk-caption-m">Showing data from 1st to 7th April 2020</span>
       <p class="govuk-body statistic-total"><%= number_with_delimiter(total_mentions(@mentions)) %></p>
     </div>
 

--- a/app/views/pages_visited/show.html.erb
+++ b/app/views/pages_visited/show.html.erb
@@ -15,15 +15,13 @@
       <%= render "govuk_publishing_components/components/table", {
           sortable: true,
           head: page_visited_table_headers,
-          rows: map_pages_visited_data_to_table(@presenter.unique_visitors_by_page)
+          rows: map_pages_visited_data_to_table(@presenter.items)
       } %>
     </div>
 
-    <%= render "govuk_publishing_components/components/previous_and_next_navigation", pages_visited_navigation_links %>
+    <%= render "govuk_publishing_components/components/previous_and_next_navigation", navigation_links(@presenter) %>
   </div>
 </div>
-
-
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/pages_visited/show.html.erb
+++ b/app/views/pages_visited/show.html.erb
@@ -12,15 +12,20 @@
 <p class="govuk-body govuk-!-margin-bottom-7">This is PLACEHOLDER TEXT. Users that had at least one mention of '<%= @phrase.phrase_text %>' in their user intent survey answers.</p>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <div class="table-group">
+  <div class="govuk-grid-column-three-quarters">
+    <div class="table-group equal-width-table">
       <%= render "govuk_publishing_components/components/table", {
+          sortable: true,
           head: page_visited_table_headers,
           rows: map_pages_visited_data_to_table(@presenter.unique_visitors_by_page)
       } %>
     </div>
+
+    <%= render "govuk_publishing_components/components/previous_and_next_navigation", pages_visited_navigation_links %>
   </div>
 </div>
+
+
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/pages_visited/show.html.erb
+++ b/app/views/pages_visited/show.html.erb
@@ -7,8 +7,6 @@
 <span class="govuk-caption-xl"><%= @phrase.phrase_text %></span>
 <h1 class="govuk-heading-xl">Pages users visited</h1>
 
-<p class="govuk-body govuk-!-margin-bottom-7">Last updated 6 April 2020 9:04am</p>
-
 <p class="govuk-body govuk-!-margin-bottom-7">This is PLACEHOLDER TEXT. Users that had at least one mention of '<%= @phrase.phrase_text %>' in their user intent survey answers.</p>
 
 <div class="govuk-grid-row">

--- a/app/views/phrase/show.html.erb
+++ b/app/views/phrase/show.html.erb
@@ -30,7 +30,7 @@
     <div class="trend-group">
       <h2 class="govuk-heading-m"><%= link_to "Pages users visited", pages_visited_path(@phrase) %></h2>
       <p class="govuk-body">Based on most pageviews for users that said <%= @phrase.phrase_text %> in past 7 days</p>
-      <%= render 'ordered_list', items: @pages_visited, item_text_prop: :base_path %>
+      <%= render 'ordered_list', items: @pages_visited, item_text_prop: :base_path, item_link_prop: :govuk_link %>
     </div>
   </div>
 </div>

--- a/app/views/phrase/show.html.erb
+++ b/app/views/phrase/show.html.erb
@@ -7,14 +7,12 @@
 <span class="govuk-caption-xl">Trending phrases</span>
 <h1 class="govuk-heading-xl"><%= @phrase.phrase_text %></h1>
 
-<p class="govuk-body govuk-!-margin-bottom-7">Last updated 6 April 2020 9:04am</p>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <div class="chart-group">
       <h2 class="govuk-heading-m">
         <%= link_to "Number of mentions", number_of_mentions_path(@phrase) %>
-        <span class="govuk-caption-m">In the past 7 days</span>
+        <span class="govuk-caption-m">Showing data from 1st to 7th April 2020</span>
       </h2>
 
       <p class="govuk-body statistic-total"><%= number_with_delimiter(total_mentions(@mentions)) %></p>
@@ -29,7 +27,7 @@
   <div class="govuk-grid-column-two-thirds">
     <div class="trend-group">
       <h2 class="govuk-heading-m"><%= link_to "Pages users visited", pages_visited_path(@phrase) %></h2>
-      <p class="govuk-body">Based on most pageviews for users that said <%= @phrase.phrase_text %> in past 7 days</p>
+      <p class="govuk-body">Based on most pageviews for users that said <%= @phrase.phrase_text %> from 1st to 7th April 2020</p>
       <%= render 'ordered_list', items: @pages_visited, item_text_prop: :base_path, item_link_prop: :govuk_link %>
     </div>
   </div>
@@ -40,7 +38,7 @@
     <div class="table-group">
       <h2 class="govuk-heading-m">
         Devices used
-        <span class="govuk-caption-m">In the past 7 days</span>
+        <span class="govuk-caption-m">Showing data from 1st to 7th April 2020</span>
       </h2>
 
       <%= render "govuk_publishing_components/components/table", {
@@ -64,7 +62,7 @@
     <div class="text-group">
       <h2 class="govuk-heading-m">
         <%= link_to "How users used this phrase", phrase_usage_path(@phrase) %>
-        <span class="govuk-caption-m">In the past 7 days</span>
+        <span class="govuk-caption-m">Showing data from 1st to 7th April 2020</span>
       </h2>
 
       <% @survey_answers_containing_phrase.each do |sa| %>

--- a/app/views/phrase_usage/show.html.erb
+++ b/app/views/phrase_usage/show.html.erb
@@ -16,12 +16,14 @@
     <div class="text-group">
       <p class="govuk-body">In the past 7 days</p>
 
-      <% @survey_answers_containing_phrase.each do |answer| %>
+      <% @presenter.survey_answers_containing_phrase.each do |answer| %>
         <%= render "govuk_publishing_components/components/inset_text", {
             text: highlighted_survey_answer_html(answer.answer, @phrase.phrase_text)
         } %>
       <% end %>
     </div>
+
+    <%= render "govuk_publishing_components/components/previous_and_next_navigation", phrase_usage_navigation_links %>
   </div>
 </div>
 

--- a/app/views/phrase_usage/show.html.erb
+++ b/app/views/phrase_usage/show.html.erb
@@ -7,14 +7,12 @@
 <span class="govuk-caption-xl"><%= @phrase.phrase_text %></span>
 <h1 class="govuk-heading-xl">How users used this phrase</h1>
 
-<p class="govuk-body govuk-!-margin-bottom-7">Last updated 6 April 2020 9:04am</p>
-
 <p class="govuk-body govuk-!-margin-bottom-7">This is PLACEHOLDER TEXT. Users that had at least one mention of '<%= @phrase.phrase_text %>' in their user intent survey answers.</p>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <div class="text-group">
-      <p class="govuk-body">In the past 7 days</p>
+      <p class="govuk-body">Showing data from 1st to 7th April 2020</p>
 
       <% @presenter.survey_answers_containing_phrase.each do |answer| %>
         <%= render "govuk_publishing_components/components/inset_text", {

--- a/app/views/phrase_usage/show.html.erb
+++ b/app/views/phrase_usage/show.html.erb
@@ -14,14 +14,14 @@
     <div class="text-group">
       <p class="govuk-body">Showing data from 1st to 7th April 2020</p>
 
-      <% @presenter.survey_answers_containing_phrase.each do |answer| %>
+      <% @presenter.items.each do |answer| %>
         <%= render "govuk_publishing_components/components/inset_text", {
             text: highlighted_survey_answer_html(answer.answer, @phrase.phrase_text)
         } %>
       <% end %>
     </div>
 
-    <%= render "govuk_publishing_components/components/previous_and_next_navigation", phrase_usage_navigation_links %>
+    <%= render "govuk_publishing_components/components/previous_and_next_navigation", navigation_links(@presenter) %>
   </div>
 </div>
 

--- a/app/views/summary/index.html.erb
+++ b/app/views/summary/index.html.erb
@@ -2,8 +2,6 @@
   User intent survey
 </h1>
 
-<p class="govuk-body govuk-!-margin-bottom-7">Last updated 6 April 2020 9:04am</p>
-
 <%= form_with(url: "/summary", method: "get") do %>
   <%= render "govuk_publishing_components/components/search", {
       inline_label: false,

--- a/app/views/summary/index.html.erb
+++ b/app/views/summary/index.html.erb
@@ -10,7 +10,7 @@
   } %>
 <% end %>
 
-<p class="govuk-body">Showing <span class="govuk-!-font-weight-bold"><%= @presenter.pagination.total_items %></span> content pages where users have given survey answers</p>
+<p class="govuk-body">Showing <span class="govuk-!-font-weight-bold"><%= @presenter.total_items %></span> content pages where users have given survey answers</p>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
@@ -24,4 +24,4 @@
   </div>
 </div>
 
-<%= render "govuk_publishing_components/components/previous_and_next_navigation", navigation_links %>
+<%= render "govuk_publishing_components/components/previous_and_next_navigation", navigation_links(@presenter) %>

--- a/app/views/trending/index.html.erb
+++ b/app/views/trending/index.html.erb
@@ -4,15 +4,13 @@
   User intent survey trends
 </h1>
 
-<p class="govuk-body govuk-!-margin-bottom-7">Last updated 6 April 2020 9:04am</p>
-
 <p class="govuk-body govuk-!-margin-bottom-7">Placeholder text. This is analysed user intent survey data from GOV.UK. <a href="#">Find out how we analysed the data</a>.</p>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-half">
     <div class="trend-group">
       <h2 class="govuk-heading-m">Top visited pages on GOV.UK</h2>
-      <p class="govuk-body">Most pageviews in past 7 days</p>
+      <p class="govuk-body">Most pageviews from 1st to 7th April 2020</p>
       <%= render 'ordered_list', items: @top_pages, item_text_prop: :base_path, item_link_prop: :govuk_link %>
     </div>
   </div>


### PR DESCRIPTION
This PR adds pagination to the pages visited page, the page phrases page, as well as updating the table styles for the sortable table to remove zebra striping and make it visually consistent with a reguar `.govuk-table`.

This PR also includes some other changes, such as reducing the number of pages and mentions on the phrase detail page.