### PR TITLE
Make import faster

### DIFF
--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -1,6 +1,8 @@
 require "elasticsearch/model"
 
 class Survey < ApplicationRecord
+  attr_accessor :no_index
+
   belongs_to :organisation
   belongs_to :visitor
   has_many :visits, dependent: :destroy
@@ -10,7 +12,9 @@ class Survey < ApplicationRecord
   has_one :survey_visits, dependent: :destroy
 
   include Elasticsearch::Model
-  include Elasticsearch::Model::Callbacks
+  after_commit lambda { __elasticsearch__.index_document  },  on: :create, unless: -> { no_index }
+  after_commit lambda { __elasticsearch__.update_document },  on: :update
+  after_commit lambda { __elasticsearch__.delete_document },  on: :destroy
 
   mapping do
     indexes :responses, type: "text", analyzer: "english"


### PR DESCRIPTION
* Reduces the time taken to import data to 30 minutes.
* Uses ActiveRecord caching to speed up finds
* Disables ES indexing for creating some records,
as the associations for those records hadn't yet
been created anyway (so would have to be re-done)
* Suppresses logs as they will marginally slow it down
and the logs can reach hundreds of mb in dev env