### PR TITLE
Add Concourse pipeline for continuous deployment

### DIFF
--- a/concourse.yml
+++ b/concourse.yml
@@ -1,0 +1,25 @@
+resources:
+  - name: git-master
+    type: git
+    source:
+      branch: master
+      uri: https://github.com/alphagov/govuk-user-intent-survey-explorer
+  - name: paas-app
+    type: cf
+    source:
+      api: https://api.cloud.service.gov.uk
+      organization: govuk_development
+      space: sandbox
+      username: ((paas-username))
+      password: ((paas-password))
+
+
+jobs:
+  - name: deploy-to-paas
+    plan:
+      - get: git-master
+        trigger: true
+      - put: paas-app
+        params:
+          manifest: git-master/manifest.yml
+          path: git-master

--- a/manifest.yml
+++ b/manifest.yml
@@ -8,3 +8,4 @@ applications:
   memory: 256M
   buildpacks:
   - ruby_buildpack
+  command: bundle exec rake db:migrate


### PR DESCRIPTION
This PR adds a Concourse pipeline for continuous deployment, implicitly relying on tests from the GitHub Action hook to ensure the app introduces no breaking changes.

Whilst this commit does push to PaaS, we should consider zero-downtime deployment for a future iteration.