### PR TITLE
Run app after migration

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -8,4 +8,4 @@ applications:
   memory: 256M
   buildpacks:
   - ruby_buildpack
-  command: bundle exec rake db:migrate
+  command: bundle exec rake db:migrate && rails s


### PR DESCRIPTION
This PR adds the missing `rails s` command to actually run the app after migrations.