### PR TITLE
Limit frequent phrases and user groups on overview page

### DIFF
--- a/app/controllers/trending_controller.rb
+++ b/app/controllers/trending_controller.rb
@@ -18,7 +18,7 @@ private
   end
 
   def most_frequent_phrases
-    Phrase.most_frequent(filter_start_date, filter_end_date)
+    Phrase.most_frequent(filter_start_date, filter_end_date).take(10)
   end
 
   def top_user_groups


### PR DESCRIPTION
This PR limits the frequent phrases and user groups on the overview page to a maximum of 10. It also updates the UserGroup model to remove the limit there.