### PR TITLE
Adds content search page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem "pg", "~> 1"
 gem 'elasticsearch-rails', '~> 6.1.0'
 gem 'elasticsearch-model', '~> 6.1.0'
 gem 'elasticsearch-persistence', '~> 6.1.0'
-
+gem 'gds-api-adapters', '~> 63.6'
 gem 'kaminari'
 
 gem "chartkick", "~> 3.3.1"
@@ -35,6 +35,7 @@ group :development, :test do
   gem "rubocop-govuk", "~> 3"
   gem "factory_bot_rails"
   gem "guard-rspec"
+  gem 'pry', '~> 0.12.2'
 end
 
 group :test do
@@ -42,6 +43,7 @@ group :test do
   gem "webmock", "~> 3"
   gem "capybara"
   gem "elasticsearch-extensions"
+  gem "mocha"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,7 +116,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     ffi (1.12.1)
     formatador (0.2.5)
-    gds-api-adapters (63.3.0)
+    gds-api-adapters (63.6.0)
       addressable
       link_header
       null_logger
@@ -199,11 +199,12 @@ GEM
     method_source (0.9.2)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2019.1009)
+    mime-types-data (3.2020.0425)
     mimemagic (0.3.4)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.0)
+    mocha (1.11.2)
     msgpack (1.3.1)
     multi_json (1.14.1)
     multipart-post (2.1.1)
@@ -224,11 +225,11 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    public_suffix (4.0.3)
+    public_suffix (4.0.5)
     puma (4.3.3)
       nio4r (~> 2.0)
-    rack (2.1.2)
-    rack-cache (1.11.0)
+    rack (2.2.2)
+    rack-cache (1.11.1)
       rack (>= 0.4)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -366,7 +367,7 @@ GEM
       thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.6)
+    unf_ext (0.0.7.7)
     unicode-display_width (1.7.0)
     unicorn (5.5.2)
       kgio (~> 2.6)
@@ -400,12 +401,15 @@ DEPENDENCIES
   elasticsearch-persistence (~> 6.1.0)
   elasticsearch-rails (~> 6.1.0)
   factory_bot_rails
+  gds-api-adapters (~> 63.6)
   govuk_publishing_components (~> 21.21)
   guard-rspec
   jbuilder (~> 2.7)
   kaminari
   listen (>= 3.0.5, < 3.2)
+  mocha
   pg (~> 1)
+  pry (~> 0.12.2)
   puma (~> 4.3)
   rails (~> 6.0.2, >= 6.0.2.1)
   rails-erd (~> 1.6)

--- a/app/assets/stylesheets/_overwrites.scss
+++ b/app/assets/stylesheets/_overwrites.scss
@@ -1,3 +1,31 @@
 .govuk-grid-column-one-half--word-break-all {
   word-break: break-all;
 }
+
+.govuk-table--sortable .govuk-table__row:nth-child(even){
+  background-color: transparent;
+}
+
+.govuk-table--sortable .govuk-table__cell:nth-child(even){
+  background-color: #f3f2f1;
+}
+
+.display-block {
+  display: block;
+}
+
+.govuk-table--sortable .govuk-table__header :not(.govuk-table__header--active) :not(.app-table__sort-link) {
+  background-color: #b1b4b6;
+}
+
+tr.govuk-table__row {
+  border-top: 1px solid #b1b4b6;
+}
+
+span.phrase {
+  background-color: #f3f2f1;
+  border-radius: 5px;
+  padding: 3px 7px 3px 7px;
+  margin: 0px 1px 0px 1px;
+  line-height: 1.7;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,6 @@
 @import "govuk_publishing_components/all_components";
 @import "overwrites";
+@import "pages";
 
 a {
   color: #1D70B8;

--- a/app/assets/stylesheets/pages.scss
+++ b/app/assets/stylesheets/pages.scss
@@ -1,3 +1,6 @@
 // Place all the styles related to the pages controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+.govuk-grid-column-full--background-light-grey {
+  background-color: govuk-colour("light-grey");
+}

--- a/app/controllers/concerns/searchable.rb
+++ b/app/controllers/concerns/searchable.rb
@@ -1,0 +1,55 @@
+module Searchable
+  extend ActiveSupport::Concern
+
+  included do
+    helper_method :q, :from_date, :to_date, :from_date_as_datetime, :to_date_as_datetime
+  end
+
+  def search_params
+    params.permit(:q, :sort_key, :sort_dir, from_date: %i[day month year], to_date: %i[day month year])
+  end
+
+  def from_date
+    search_params.fetch(:from_date, default_from_date)
+  end
+
+  def to_date
+    search_params.fetch(:to_date, default_to_date)
+  end
+
+  def default_from_date
+    default = (DateTime.now - 7.days).beginning_of_day
+    {
+      day: default.day,
+      month: default.month,
+      year: default.year,
+    }
+  end
+
+  def default_to_date
+    default = DateTime.now
+    {
+      day: default.day,
+      month: default.month,
+      year: default.year,
+    }
+  end
+
+  def q
+    search_params[:q].to_s
+  end
+
+  def from_date_as_datetime
+    date_parameters_to_datetime(from_date)
+  end
+
+  def to_date_as_datetime
+    date_parameters_to_datetime(to_date)
+  end
+
+  def date_parameters_to_datetime(date_parameters)
+    DateTime.new(date_parameters[:year].to_i, date_parameters[:month].to_i, date_parameters[:day].to_i)
+  rescue ArgumentError
+    nil
+  end
+end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,7 @@
 class PagesController < ApplicationController
+  include Searchable
+  helper_method :sort_key, :sort_dir
+
   def show
     @page = Page.find(params[:id])
     surveys = Survey.where(full_path: @page.base_path)
@@ -8,5 +11,33 @@ class PagesController < ApplicationController
         grouped_answers[survey_answer.question] << survey_answer
       end
     end
+  end
+
+  def index
+    @presenter = PagesPresenter.new(pages, search_page, search_params, sort_key, sort_dir, from_date_as_datetime, to_date_as_datetime)
+  end
+
+private
+
+  def pages
+    @pages ||= begin
+      Page.search_by_base_path(q, from_date_as_datetime, to_date_as_datetime, sort_key, sort_dir)
+    end
+  end
+
+  def sort_key
+    default_key = "feedback_comments"
+    key = params[:sort_key] || default_key
+    %w[page_base_path feedback_comments].include?(key) ? key : default_key
+  end
+
+  def sort_dir
+    default_dir = "desc"
+    dir = params[:sort_dir] || default_dir
+    %w[desc asc].include?(dir) ? dir : default_dir
+  end
+
+  def search_page
+    params[:page] ||= 0
   end
 end

--- a/app/controllers/survey_searches_controller.rb
+++ b/app/controllers/survey_searches_controller.rb
@@ -1,5 +1,5 @@
 class SurveySearchesController < ApplicationController
-  helper_method :q, :from_date, :to_date
+  include Searchable
 
   def show
     @results = results
@@ -20,8 +20,8 @@ private
               },
               range: {
                 started_at: {
-                  gte: date_parameters_to_datetime(from_date),
-                  lte: date_parameters_to_datetime(to_date),
+                  gte: date_parameters_to_datetime(from_date).strftime("%F"),
+                  lte: date_parameters_to_datetime(to_date).strftime("%F"),
                 },
               },
             ],
@@ -33,27 +33,5 @@ private
       total: response.results.total,
       results: response.records,
     }
-  end
-
-  def search_params
-    params.permit(:q, from_date: %i[day month year], to_date: %i[day month year])
-  end
-
-  def from_date
-    search_params.fetch(:from_date, {})
-  end
-
-  def to_date
-    search_params.fetch(:to_date, {})
-  end
-
-  def q
-    search_params[:q].to_s
-  end
-
-  def date_parameters_to_datetime(date_parameters)
-    DateTime.new(date_parameters[:year].to_i, date_parameters[:month].to_i, date_parameters[:day].to_i).strftime("%F")
-  rescue ArgumentError
-    nil
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -36,4 +36,32 @@ module ApplicationHelper
 
     links
   end
+
+  def human_readable_date_range(from, to)
+    # https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#dates
+    format = "%-d %B %Y"
+    if from && to
+      "Showing data from #{from.strftime(format)} to #{to.strftime(format)}"
+    elsif from && !to
+      "Showing data from #{from.strftime(format)}"
+    elsif !from && to
+      "Showing data to #{to.strftime(format)}"
+    else
+      "Showing all data"
+    end
+  end
+
+  def human_readable_date_duration(from, to)
+    num_days = nil
+    if from && to
+      num_days = (to - from).to_i
+    elsif from
+      num_days = (DateTime.now - from).to_i
+    elsif to
+      num_days = (DateTime.now - to).to_i
+    end
+    if num_days
+      "Showing data for #{num_days} #{'day'.pluralize(num_days)}"
+    end
+  end
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -45,4 +45,16 @@ class Page < ApplicationRecord
       .order("#{sort_key} #{sort_dir}")
       .pluck("pages.base_path", "count(distinct(page_visits.visit_id)) as unique_visitors")
   end
+
+  def self.search_by_base_path(query, start_date, end_date, sort_key, sort_dir)
+    date_range = start_date..end_date
+
+    Page.joins(page_visits: [{ visit: [{ survey_visit: [{ survey: [{ survey_answers: [{ mentions: :phrase }] }] }] }] }])
+      .where("surveys.started_at" => date_range)
+      .where("pages.base_path like ?", "%#{query}%")
+      .group("pages.id")
+      .order("#{sort_key} #{sort_dir}")
+      .pluck("pages.base_path as page_base_path", "count(distinct(surveys.id)) as feedback_comments", "pages.id")
+      .map { |base_path, feedback_comments, page_id| { base_path: base_path, survey_count: feedback_comments, page_id: page_id } }
+  end
 end

--- a/app/models/phrase.rb
+++ b/app/models/phrase.rb
@@ -11,4 +11,15 @@ class Phrase < ApplicationRecord
       .group("phrases.id, phrases.phrase_text")
       .order("total_mentions desc")
   end
+
+  def self.top_phrases_for_page(page_id, start_date, end_date)
+    date_range = start_date..end_date
+
+    Phrase.joins(mentions: [{ survey_answer: [{ survey: [{ survey_visit: [{ visit: :page_visits }] }] }] }])
+      .where("surveys.started_at" => date_range)
+      .where("page_visits.page_id" => page_id)
+      .group("phrases.id")
+      .order("count(mentions.survey_answer_id) desc")
+      .pluck("phrases.phrase_text")
+  end
 end

--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -9,7 +9,7 @@ class Survey < ApplicationRecord
   has_many :questions, through: :visits
   has_many(:survey_answers, -> { order(:question_id) }, inverse_of: :survey)
   has_many :survey_user_groups, dependent: :destroy
-  has_one :survey_visits, dependent: :destroy
+  has_one :survey_visit, dependent: :destroy
 
   include Elasticsearch::Model
   after_commit lambda { __elasticsearch__.index_document  },  on: :create, unless: -> { no_index }

--- a/app/presenters/pages_presenter.rb
+++ b/app/presenters/pages_presenter.rb
@@ -1,0 +1,135 @@
+class PagesPresenter
+  include Rails.application.routes.url_helpers
+  include ActionView::Helpers::TagHelper
+  attr_reader :items
+  delegate :page, :total_pages, :total_items, to: :pagination
+
+  def initialize(pages, search_results_page, url_params, sort_key, sort_dir, start_date, end_date)
+    @pagination = PaginationPresenter.new(page: search_results_page, items_per_page: 50, total_items: pages.count)
+    @items = pagination.paginate(pages)
+    @url_params = url_params
+    @sort_key = sort_key
+    @sort_dir = sort_dir
+    @start_date = start_date
+    @end_date = end_date
+  end
+
+  def rows
+    items.map do |page|
+      [
+        { text: page_text(page[:base_path]) },
+        { text: page[:survey_count], format: "numeric" },
+        { text: top_phrases(page) },
+      ]
+    end
+  end
+
+  def head
+    [
+      page_title_head,
+      surveys_answered_head,
+      {
+        text: "Most frequent phrases",
+      },
+    ]
+  end
+
+private
+
+  attr_reader :pagination, :url_params, :sort_key, :sort_dir, :start_date, :end_date
+  attr_accessor :page_titles
+
+  def page_text(base_path)
+    title = page_title(base_path)
+
+    content_tag(:a, title, href: base_path, class: "display-block") +
+      content_tag(:span, base_path, class: "govuk-body-s display-block")
+  end
+
+  def page_title(base_path)
+    # Search API doesn't index all documents, so it won't always return
+    # a result for every base path we pass it.
+    return search_api_page_titles[base_path] if search_api_page_titles.has_key?(base_path)
+
+    # If the search results don't include the base path we want
+    # we hit the Content Store API, which will
+    begin
+      content_store_page_title(base_path)
+    rescue GdsApi::ContentStore::ItemNotFound, GdsApi::InvalidUrl
+      # Sometimes we can have a url that the content store does not recognise
+      # because we're relying on urls from a non canonical source
+      # (for example if it has a lot of parameters in it or it's a sub item of another)
+      # We need to find a long term solution to this
+      ""
+    end
+  end
+
+  def search_api_page_titles
+    @search_api_page_titles ||= begin
+      Services.search_api.search(
+        count: items.count,
+        filter_link: item_base_paths,
+        fields: %i[link title],
+      )
+        .to_hash["results"]
+        .each_with_object({}) { |result, hash| hash[result["link"]] = result["title"] }
+    end
+  end
+
+  def item_base_paths
+    @item_base_paths ||= items.map { |item| item[:base_path] }
+  end
+
+  def content_store_page_title(base_path)
+    Services.content_store.content_item(base_path)["title"]
+  end
+
+  def page_title_head
+    key = "page_base_path"
+    {
+      text: "Page title",
+      href: href(key),
+    }.merge(sort_direction(key))
+  end
+
+  def surveys_answered_head
+    key = "feedback_comments"
+    {
+      text: "Surveys answered",
+      format: "numeric",
+      href: href(key),
+    }.merge(sort_direction(key))
+  end
+
+  def href(key)
+    direction_for_link = sort_dir
+    if currently_sorting_by_key?(key)
+      direction_for_link = opposite_sort_dir
+    end
+
+    sort_params = { sort_key: key, sort_dir: direction_for_link }
+    pages_path(url_params.merge(sort_params))
+  end
+
+  def opposite_sort_dir
+    sort_dir == "desc" ? "asc" : "desc"
+  end
+
+  def sort_direction(key)
+    return {} unless currently_sorting_by_key?(key)
+
+    { sort_direction: sort_dir }
+  end
+
+  def currently_sorting_by_key?(key)
+    key == sort_key
+  end
+
+  def top_phrases(page)
+    phrases = Phrase.top_phrases_for_page(page[:page_id], start_date, end_date).take(3)
+
+    content_tag(:span, phrases.first, class: "phrase") +
+      content_tag(:span, phrases.second, class: "phrase") +
+      content_tag(:span, phrases.third, class: "phrase")
+  end
+end

--- a/app/presenters/pagination_presenter.rb
+++ b/app/presenters/pagination_presenter.rb
@@ -2,8 +2,8 @@ class PaginationPresenter
   include Kaminari::Helpers::HelperMethods
   attr_reader :page, :total_items, :total_pages
 
-  def initialize(page: 1, total_items:)
-    @items_per_page = 15
+  def initialize(page: 1, total_items:, items_per_page: 15)
+    @items_per_page = items_per_page
 
     @page = page.to_i
     @total_items = total_items

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -1,0 +1,153 @@
+<%= render "govuk_publishing_components/components/title", {
+    title: "Content pages with feedback comments"
+} %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h4 class="govuk-heading-s"><%= human_readable_date_range(from_date_as_datetime, to_date_as_datetime) %></h4>
+  </div>
+</div>
+<%= form_with(url: pages_url, method: "get") do %>
+  <%= hidden_field_tag :sort_key, sort_key %>
+  <%= hidden_field_tag :sort_dir, sort_dir %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <div class="govuk-grid-column-full--background-light-grey govuk-!-padding-4">
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-full">
+            <h4 class="govuk-heading-s"><%= human_readable_date_duration(from_date_as_datetime, to_date_as_datetime) %></h4>
+            <%= render "govuk_publishing_components/components/details", {
+                title: "Change time period"
+            } do %>
+              <div class="govuk-grid-row govuk-!-margin-top-4">
+                <div class="govuk-grid-column-one-third">
+                  <%= render "govuk_publishing_components/components/date_input", {
+                    name: "from_date",
+                    legend_text: "Visits on or after",
+                    items:
+                      [
+                        {
+                          label: "Day",
+                          name: "day",
+                          width: 2,
+                          value: from_date[:day],
+                        },
+                        {
+                          label: "Month",
+                          name: "month",
+                          width: 2,
+                          value: from_date[:month],
+                        },
+                        {
+                          label: "Year",
+                          name: "year",
+                          width: 4,
+                          value: from_date[:year],
+                        },
+                      ]
+                  } %>
+                </div>
+                <div class="govuk-grid-column-one-third">
+                  <%= render "govuk_publishing_components/components/date_input", {
+                    name: "to_date",
+                    legend_text: "Visits on or before",
+                    items:
+                      [
+                        {
+                          label: "Day",
+                          name: "day",
+                          width: 2,
+                          value: to_date[:day],
+                        },
+                        {
+                          label: "Month",
+                          name: "month",
+                          width: 2,
+                          value: to_date[:month],
+                        },
+                        {
+                          label: "Year",
+                          name: "year",
+                          width: 4,
+                          value: to_date[:year],
+                        },
+                      ]
+                  } %>
+                </div>
+              </div>
+            <% end %>
+          </div>
+        </div>
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-two-thirds">
+            <%= render "govuk_publishing_components/components/input", {
+              label: {
+                text: "Search for a title or URL"
+              },
+              name: "q",
+              value: q
+            } %>
+          </div>
+        </div>
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-one-third">
+            <%= render "govuk_publishing_components/components/select", {
+              id: "dropdown1-1",
+              full_width: true,
+              label: "What was the user trying to do?",
+              name: "verb",
+              options: [
+                {
+                  text: "Intentionally left blank",
+                  value: "option1"
+                },
+              ]
+            } %>
+          </div>
+          <div class="govuk-grid-column-one-third">
+            <%= render "govuk_publishing_components/components/select", {
+              id: "dropdown1-1",
+              full_width: true,
+              label: "About what?",
+              name: "argument",
+              options: [
+                {
+                  text: "Intentionally left blank",
+                  value: "option1"
+                },
+              ]
+            } %>
+          </div>
+        </div>
+        <div class="govuk-grid-row govuk-!-margin-bottom-4">
+          <div class="govuk-grid-column-full">
+            <%= render "govuk_publishing_components/components/button", {
+              text: "Filter"
+            } %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>
+
+<div class="govuk-grid-row govuk-!-margin-top-8">
+  <div class="govuk-grid-column-full">
+    <p class="govuk-body"><%= "Showing <span class='govuk-!-font-weight-bold'>#{@presenter.total_items}</span> content #{"page".pluralize(@presenter.total_items)} where users have given survey answers".html_safe %></p>
+  </div>
+</div>
+<div class="govuk-grid-row govuk-!-margin-top-0">
+  <div class="govuk-grid-column-full">
+    <%= render "govuk_publishing_components/components/table", {
+      sortable: true,
+      head: @presenter.head,
+      rows: @presenter.rows
+    } %>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= render "govuk_publishing_components/components/previous_and_next_navigation", navigation_links(@presenter) %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
   resources :mentions, only: [:show]
 
   get "pages/search" => "page_searches#show", as: :page_search
-  resources :pages, only: [:show]
+  resources :pages, only: %i[show index]
   get "surveys/search" => "survey_searches#show", as: :survey_search
   resources :surveys, only: [:show]
 

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,0 +1,11 @@
+require "gds_api/search"
+
+module Services
+  def self.search_api
+    @search_api ||= GdsApi::Search.new("https://www.gov.uk/api")
+  end
+
+  def self.content_store
+    @content_store ||= GdsApi::ContentStore.new("https://www.gov.uk/api")
+  end
+end

--- a/spec/features/pages_spec.rb
+++ b/spec/features/pages_spec.rb
@@ -1,0 +1,68 @@
+require "spec_helper"
+require_relative "../spec_helpers/phrase_helper"
+
+RSpec.feature "pages index" do
+  scenario "shows phrases for pages" do
+    pages = []
+    pages << FactoryBot.create(:page, base_path: "/marry-a-birdperson-step-by-step")
+    pages << FactoryBot.create(:page, base_path: "/get-your-interdimensional-tv-licence")
+    pages << FactoryBot.create(:page, base_path: "/portal-gun-repairs")
+    pages << FactoryBot.create(:page, base_path: "/council-of-ricks/minutes")
+
+    stub_search_api(pages.map(&:base_path))
+    stub_content_store_api("/portal-gun-repairs")
+
+    start_date = DateTime.now - 1.day
+    pages.each_with_index do |page, index|
+      create_phrases_for_page(page, start_date, 3, index)
+    end
+
+    visit pages_path
+
+    expect(page).to have_link("Step by step: marry a birdperson")
+    expect(page).to have_link("Get your portal gun repaired")
+    expect(page).to have_link("Get your interdimensional TV licence")
+    expect(page).to have_link("Council of Ricks: Minutes")
+    expect(page).to have_content("I need assistance 1")
+    expect(page).to have_content("I need assistance 2")
+    expect(page).to have_content("I need assistance 3")
+    expect(page).to have_content("Showing 4 content pages where users have given survey answers")
+    expect(page).to have_content("Next page")
+  end
+end
+
+def stub_search_api(base_paths)
+  # Search API doesn't index all documents, so it won't always return
+  # a result for every base path we pass it.
+  # Here, we intentionally leave out one of the results to test
+  # that it then hits the Content Store API with the remaining
+  # base path (as that is guaranteed to have the remaining page)
+  results = {
+    "results" => [
+      {
+          "link" => "/marry-a-birdperson-step-by-step",
+          "title" => "Step by step: marry a birdperson",
+      },
+      {
+          "link" => "/get-your-interdimensional-tv-licence",
+          "title" => "Get your interdimensional TV licence",
+      },
+      {
+          "link" => "/council-of-ricks/minutes",
+          "title" => "Council of Ricks: Minutes",
+      },
+    ],
+  }
+
+  filters = {
+    count: base_paths.count,
+    filter_link: base_paths,
+    fields: %i[link title],
+  }
+  GdsApi::Search.any_instance.stubs(:search).with(filters).returns(results)
+end
+
+def stub_content_store_api(base_path)
+  result = { "title" => "Get your portal gun repaired" }
+  GdsApi::ContentStore.any_instance.stubs(:content_item).with(base_path).returns(result)
+end

--- a/spec/models/phrase_spec.rb
+++ b/spec/models/phrase_spec.rb
@@ -47,4 +47,51 @@ RSpec.describe Phrase, type: :model do
       end
     end
   end
+
+  describe "top_phrases_for_page" do
+    context "with empty database" do
+      it "returns no pages" do
+        start_date = Date.new(2020, 3, 2)
+        end_date = Date.new(2020, 3, 20)
+        result = Phrase.top_phrases_for_page(1, start_date, end_date)
+        expect(result).to be_empty
+      end
+    end
+
+    context "page without any phrases" do
+      it "returns no pages" do
+        page = FactoryBot.create(:page)
+        start_date = Date.new(2020, 3, 2)
+        end_date = Date.new(2020, 3, 20)
+        result = Phrase.top_phrases_for_page(page.id, start_date, end_date)
+        expect(result).to be_empty
+      end
+    end
+
+    context "with populated database" do
+      it "returns phrases in order of number of mentions" do
+        page = FactoryBot.create(:page)
+
+        start_date = Date.new(2020, 3, 10)
+        end_date = Date.new(2020, 3, 20)
+
+        create_phrases_for_page(page, start_date, 3)
+
+        result = Phrase.top_phrases_for_page(page.id, start_date, end_date)
+        expect(result).to eq(["I need assistance 3", "I need assistance 2", "I need assistance 1"])
+      end
+
+      it "returns no pages when date filter matches no surveys" do
+        page = FactoryBot.create(:page)
+
+        start_date = Date.new(2020, 3, 10)
+        end_date = Date.new(2020, 3, 20)
+
+        create_phrases_for_page(page, end_date + 1.day, 3)
+
+        result = Phrase.top_phrases_for_page(page.id, start_date, end_date)
+        expect(result).to be_empty
+      end
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,7 @@ RSpec.configure do |config|
   config.expose_dsl_globally = false
   config.infer_spec_type_from_file_location!
   config.use_transactional_fixtures = true
+  config.mock_with :mocha
 
   config.include FactoryBot::Syntax::Methods
 

--- a/spec/spec_helpers/phrase_helper.rb
+++ b/spec/spec_helpers/phrase_helper.rb
@@ -1,0 +1,15 @@
+def create_phrases_for_page(page, survey_started_at, number_of_phrases, minimum_number_of_mentions = 1)
+  visitor = FactoryBot.create(:visitor)
+  survey = FactoryBot.create(:survey, started_at: survey_started_at)
+  survey_answer = FactoryBot.create(:survey_answer, survey: survey)
+  number_of_phrases.times do |index|
+    phrase = FactoryBot.create(:phrase, phrase_text: "I need assistance #{index + 1}")
+    (index + minimum_number_of_mentions).times do
+      FactoryBot.create(:mention, phrase: phrase, survey_answer: survey_answer)
+    end
+  end
+
+  visit = FactoryBot.create(:visit, visitor: visitor)
+  FactoryBot.create(:page_visit, page: page, visit: visit)
+  FactoryBot.create(:survey_visit, survey: survey, visit: visit)
+end

--- a/spec/views/mentions/show.html.erb_spec.rb
+++ b/spec/views/mentions/show.html.erb_spec.rb
@@ -1,5 +1,0 @@
-require "spec_helper"
-
-RSpec.describe "number_of_mentions/show.html.erb", type: :view do
-  pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/spec/views/phrase/show.html.erb_spec.rb
+++ b/spec/views/phrase/show.html.erb_spec.rb
@@ -1,5 +1,0 @@
-require "spec_helper"
-
-RSpec.describe "phrase/show.html.erb", type: :view do
-  pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/spec/views/summary/index.html.erb_spec.rb
+++ b/spec/views/summary/index.html.erb_spec.rb
@@ -1,5 +1,0 @@
-require "spec_helper"
-
-RSpec.describe "summary/index.html.erb", type: :view do
-  pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/spec/views/trending/index.html.erb_spec.rb
+++ b/spec/views/trending/index.html.erb_spec.rb
@@ -1,5 +1,0 @@
-require "spec_helper"
-
-RSpec.describe "trending/index.html.erb", type: :view do
-  pending "add some examples to (or delete) #{__FILE__}"
-end


### PR DESCRIPTION
Allows users to search for a page, filter and reorder
content pages from GOV.UK according to the phrases
seen in the feedback to those pages