### PR TITLE
Wire up generic phrases page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,6 +6,11 @@ a {
   color: #1D70B8;
 }
 
+// Don't display the environment tag
+.gem-c-environment-tag {
+  display: none;
+}
+
 .govuk-table__cell {
   word-break: break-all;
 }

--- a/app/controllers/generic_phrases_controller.rb
+++ b/app/controllers/generic_phrases_controller.rb
@@ -1,14 +1,67 @@
 class GenericPhrasesController < ApplicationController
+  include Searchable
+
   def index
-    @items = [
-      {
-        verb: "to find",
-        adjective: "information",
-      },
-      {
-        verb: "acquire somthing",
-        adjective: "delivery",
-      },
-    ]
+    options = {
+      page: page,
+      sort_key: sort_key,
+      sort_direction: sort_dir,
+      verb: verb,
+      adjective: adjective,
+    }
+
+    @presenter = GenericPhrasesPresenter.new(generic_phrase_results, verb_results, adjective_results, search_params, options)
+  end
+
+private
+
+  def generic_phrase_results
+    options = {
+      sort_key: sort_key,
+      sort_dir: sort_dir,
+    }
+
+    options[:verb] = verb if verb.present?
+    options[:adjective] = adjective if adjective.present?
+
+    GenericPhrase.search(from_date_as_datetime, to_date_as_datetime, options)
+  end
+
+  def verb_results
+    Verb.unique_sorted.map(&:name)
+  end
+
+  def adjective_results
+    Adjective.unique_sorted.map(&:name)
+  end
+
+  def sort_key
+    default_key = "generic_phrase"
+
+    if params[:sort_key].present?
+      %w[generic_phrase verb adj].include?(params[:sort_key]) ? params[:sort_key] : default_key
+    else
+      default_key
+    end
+  end
+
+  def sort_dir
+    params[:sort_direction] == "desc" ? :desc : :asc
+  end
+
+  def page
+    params[:page] || 1
+  end
+
+  def verb
+    verb_param = params.permit(:verb).fetch(:verb, "")
+
+    verb_results.include?(verb_param) ? verb_param : ""
+  end
+
+  def adjective
+    adjective_param = params.permit(:adjective).fetch(:adjective, "")
+
+    adjective_results.include?(adjective_param) ? adjective_param : ""
   end
 end

--- a/app/helpers/generic_phrases_helper.rb
+++ b/app/helpers/generic_phrases_helper.rb
@@ -1,17 +1,95 @@
 module GenericPhrasesHelper
-  def map_to_table(generic_phrases)
-    generic_phrases.map do |generic_phrase|
+  def generic_phrase_table_headers(presenter)
+    column_map = {
+      "generic_phrase" => {
+        text: "Generic phrase",
+        href: "/generic_phrases?sort_key=generic_phrase&sort_direction=asc&verb=#{presenter.verb}&adjective=#{presenter.adjective}",
+      },
+      "verb" => {
+        text: "Verb",
+        href: "/generic_phrases?sort_key=verb&sort_direction=asc&verb=#{presenter.verb}&adjective=#{presenter.adjective}",
+      },
+      "adj" => {
+        text: "Adjective",
+        href: "/generic_phrases?sort_key=adj&sort_direction=asc&verb=#{presenter.verb}&adjective=#{presenter.adjective}",
+      },
+    }
+
+    if presenter.sort_key.present?
+      dir = presenter.sort_direction == :asc ? :desc : :asc
+      column_map[presenter.sort_key].merge!(
+        {
+          sort_direction: sort_directions[presenter.sort_direction],
+          href: "/generic_phrases?sort_key=#{presenter.sort_key}&sort_direction=#{dir}&verb=#{presenter.verb}&adjective=#{presenter.adjective}",
+        },
+      )
+    end
+
+    column_map.values
+  end
+
+  def map_verbs_to_table(presenter)
+    options = [
+      {
+        text: "Select...",
+        value: "",
+      },
+    ]
+
+    options += presenter.verbs.map do |verb|
+      {
+        text: verb,
+        value: verb,
+        selected: verb == presenter.verb,
+      }
+    end
+
+    options
+  end
+
+  def map_adjectives_to_table(presenter)
+    options = [
+      {
+        text: "Select...",
+        value: "",
+      },
+    ]
+
+    options += presenter.adjectives.map do |adj|
+      {
+        text: adj,
+        value: adj,
+        selected: adj == presenter.adjective,
+      }
+    end
+
+    options
+  end
+
+  def map_to_table(presenter)
+    presenter.items.map do |generic_phrase_id, generic_phrase, verb, adjective|
+      link = link_to generic_phrase, generic_phrase_path(id: generic_phrase_id)
+
       [
         {
-          text: "#{generic_phrase[:verb]}-#{generic_phrase[:adjective]}",
+          text: link,
         },
         {
-          text: generic_phrase[:verb],
+          text: verb,
         },
         {
-          text: generic_phrase[:adjective],
+          text: adjective,
         },
       ]
     end
+  end
+
+private
+
+  def sort_directions
+    {
+      asc: "ascending",
+      desc: "descending",
+    }
   end
 end

--- a/app/models/adjective.rb
+++ b/app/models/adjective.rb
@@ -1,3 +1,7 @@
 class Adjective < ApplicationRecord
   has_many :generic_phrases, dependent: :destroy
+
+  def self.unique_sorted
+    Adjective.distinct.order(:name)
+  end
 end

--- a/app/models/generic_phrase.rb
+++ b/app/models/generic_phrase.rb
@@ -2,4 +2,24 @@ class GenericPhrase < ApplicationRecord
   belongs_to :verb
   belongs_to :adjective
   has_many :phrase_generic_phrases, dependent: :destroy
+
+  def self.search(start_date, end_date, options = {})
+    options = {
+      sort_key: "generic_phrase",
+      sort_dir: :asc,
+      verb: "%",
+      adjective: "%",
+    }.merge!(options)
+
+    date_range = start_date..end_date
+
+    GenericPhrase
+      .joins(:verb, :adjective, phrase_generic_phrases: [{ phrase: [{ mentions: [{ survey_answer: :survey }] }] }])
+      .where("surveys.started_at" => date_range)
+      .where("verbs.name like ?", options[:verb])
+      .where("adjectives.name like ?", options[:adjective])
+      .group("generic_phrases.id, verbs.name, adjectives.name")
+      .order("#{options[:sort_key]} #{options[:sort_dir]}")
+      .pluck("generic_phrases.id", "concat(verbs.name, '-', adjectives.name) as generic_phrase", "verbs.name as verb", "adjectives.name as adj")
+  end
 end

--- a/app/models/verb.rb
+++ b/app/models/verb.rb
@@ -1,3 +1,7 @@
 class Verb < ApplicationRecord
   has_many :generic_phrases, dependent: :destroy
+
+  def self.unique_sorted
+    Verb.distinct.order(:name)
+  end
 end

--- a/app/presenters/generic_phrases_presenter.rb
+++ b/app/presenters/generic_phrases_presenter.rb
@@ -1,0 +1,93 @@
+class GenericPhrasesPresenter
+  include Rails.application.routes.url_helpers
+  attr_reader :pagination, :sorting, :search_params, :url_params, :options, :items, :verbs, :adjectives, :verb, :adjective
+  delegate :page, :total_pages, :total_items, to: :pagination
+  delegate :sort_key, :sort_direction, to: :sorting
+
+  def initialize(generic_phrases, verbs, adjectives, url_params, options)
+    @search_params = search_params
+    @pagination = PaginationPresenter.new(page: options[:page], total_items: generic_phrases.count)
+    @sorting = SortPresenter.new(sort_key: options[:sort_key], sort_direction: options[:sort_direction])
+    @url_params = url_params
+    @options = options
+
+    @items = pagination.paginate(generic_phrases)
+    @verbs = verbs
+    @adjectives = adjectives
+
+    @verb = options[:verb]
+    @adjective = options[:adjective]
+  end
+
+  def table_head
+    [
+      generic_phrase_head,
+      verb_head,
+      topic_head,
+    ]
+  end
+
+private
+
+  def generic_phrase_head
+    key = "generic_phrase"
+    {
+      text: "Generic phrase",
+      href: href(key),
+    }.merge(sort_direction(key))
+  end
+
+  def verb_head
+    key = "verb"
+    {
+      text: "Verb",
+      href: href(key),
+    }.merge(sort_direction(key))
+  end
+
+  def topic_head
+    key = "adj"
+    {
+      text: "Topic",
+      href: href(key),
+    }.merge(sort_direction(key))
+  end
+
+  def href(key)
+    direction_for_link = "asc"
+    if currently_sorting_by_key?(key)
+      direction_for_link = opposite_sort_dir
+    end
+
+    sort_params = { sort_key: key, sort_direction: direction_for_link }
+    generic_phrases_path(url_params.merge(sort_params).merge(filter_params))
+  end
+
+  def filter_params
+    {
+      verb: options[:verb],
+      adjective: options[:adjective],
+    }
+  end
+
+  def currently_sorting_by_key?(key)
+    key == sort_key
+  end
+
+  def opposite_sort_dir
+    options[:sort_direction] == :desc ? "asc" : "desc"
+  end
+
+  def sort_direction(key)
+    return {} unless currently_sorting_by_key?(key)
+
+    { sort_direction: sort_directions[options[:sort_direction]] }
+  end
+
+  def sort_directions
+    {
+      asc: "ascending",
+      desc: "descending",
+    }
+  end
+end

--- a/app/views/generic_phrases/index.html.erb
+++ b/app/views/generic_phrases/index.html.erb
@@ -1,74 +1,118 @@
 <%= content_for :title, "Generic phrases" %>
 
+<%= form_with(url: generic_phrases_url, method: "get") do %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full govuk-grid-column-full--background-light-grey">
+      <div class="govuk-grid-row govuk-!-margin-top-4">
+        <div class="govuk-grid-column-full">
+          <h4 class="govuk-heading-s"><%= human_readable_date_duration(from_date_as_datetime, to_date_as_datetime) %></h4>
+          <%= render "govuk_publishing_components/components/details", {
+              title: "Change time period"
+          } do %>
+            <div class="govuk-grid-row govuk-!-margin-top-4">
+              <div class="govuk-grid-column-one-third">
+                <%= render "govuk_publishing_components/components/date_input", {
+                    name: "from_date",
+                    legend_text: "Visits on or after",
+                    items:
+                        [
+                            {
+                                label: "Day",
+                                name: "day",
+                                width: 2,
+                                value: from_date[:day],
+                            },
+                            {
+                                label: "Month",
+                                name: "month",
+                                width: 2,
+                                value: from_date[:month],
+                            },
+                            {
+                                label: "Year",
+                                name: "year",
+                                width: 4,
+                                value: from_date[:year],
+                            },
+                        ]
+                } %>
+              </div>
+              <div class="govuk-grid-column-one-third">
+                <%= render "govuk_publishing_components/components/date_input", {
+                    name: "to_date",
+                    legend_text: "Visits on or before",
+                    items:
+                        [
+                            {
+                                label: "Day",
+                                name: "day",
+                                width: 2,
+                                value: to_date[:day],
+                            },
+                            {
+                                label: "Month",
+                                name: "month",
+                                width: 2,
+                                value: to_date[:month],
+                            },
+                            {
+                                label: "Year",
+                                name: "year",
+                                width: 4,
+                                value: to_date[:year],
+                            },
+                        ]
+                } %>
+              </div>
+            </div>
+          <% end %>
+        </div>
+      </div>
+
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-third">
+          <%= render "govuk_publishing_components/components/select", {
+            id: "verb-selection",
+            full_width: true,
+            label: "What was the user trying to do?",
+            name: "verb",
+            options: map_verbs_to_table(@presenter)
+          } %>
+        </div>
+        <div class="govuk-grid-column-one-third">
+          <%= render "govuk_publishing_components/components/select", {
+            id: "adjective-selection",
+            full_width: true,
+            label: "About what?",
+            name: "adjective",
+            options: map_adjectives_to_table(@presenter)
+          } %>
+        </div>
+      </div>
+
+      <div class="govuk-grid-row govuk-!-margin-bottom-4">
+        <div class="govuk-grid-column-full">
+          <%= render "govuk_publishing_components/components/button", {
+              text: "Submit"
+          } %>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>
+
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full govuk-grid-column-full--background-light-grey">
-    <div class="govuk-grid-row govuk-!-margin-top-4">
-      <div class="govuk-grid-column-full">
-        <h4 class="govuk-heading-s">Showing data from last 7 days</h4>
-        <%= render "govuk_publishing_components/components/details", {
-          title: "Change time period"
-        } %>
-      </div>
-    </div>
-
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-third">
-        <%= render "govuk_publishing_components/components/select", {
-          id: "verb-selection",
-          full_width: true,
-          label: "What was the user trying to do?",
-          name: "verb-selection",
-          options: [
-            {
-                text: "Select",
-                value: ""
-            }
-          ]
-        } %>
-      </div>
-      <div class="govuk-grid-column-one-third">
-        <%= render "govuk_publishing_components/components/select", {
-          id: "adjective-selection",
-          full_width: true,
-          label: "About what?",
-          name: "argument-selection",
-          options: [
-            {
-              text: "Select",
-              value: ""
-            }
-          ]
-        } %>
-      </div>
-    </div>
-
-    <div class="govuk-grid-row govuk-!-margin-bottom-4">
-      <div class="govuk-grid-column-full">
-        <%= render "govuk_publishing_components/components/button", {
-            text: "Submit"
-        } %>
-      </div>
-    </div>
+  <div class="govuk-grid-column-full">
+    <p class="govuk-body">Showing <span class="govuk-!-font-weight-bold"><%= @presenter.total_items %></span> content pages where users have given survey answers</p>
   </div>
 </div>
 
 <div class="govuk-grid-row">
   <%= render "govuk_publishing_components/components/table", {
       sortable: true,
-      head: [
-          {
-              text: "Generic phrase",
-              href: "/?sort_direction=desc",
-          },
-          {
-              text: "Verb",
-              href: "/?sort_direction=desc",
-          },
-          {
-              text: "Adjective",
-              href: "/?sort_direction=desc",
-          },
-      ],
-      rows: map_to_table(@items),
+      head: @presenter.table_head,
+      rows: map_to_table(@presenter),
   } %>
 </div>
+
+<%= render "govuk_publishing_components/components/previous_and_next_navigation", navigation_links(@presenter) %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,7 +21,13 @@
 
   <%= render "govuk_publishing_components/components/layout_header", {
     environment: GovukPublishingComponents::AppHelpers::Environment.current_acceptance_environment,
-    product_name: "Intent and Feedback Tool"
+    product_name: "Intent and Feedback Tool",
+    navigation_items: [
+      {
+        text: "Generic phrases",
+        href: "/generic_phrases",
+      },
+    ]
   }%>
 
   <div class="govuk-width-container">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :generic_phrases, only: [:index]
+  resources :generic_phrases, only: %i[index show]
 
   resources :mentions, only: [:show]
 

--- a/spec/factories/verbs.rb
+++ b/spec/factories/verbs.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :verb do
-    name { "to find" }
+    name { "find" }
   end
 end

--- a/spec/models/adjective_spec.rb
+++ b/spec/models/adjective_spec.rb
@@ -1,0 +1,15 @@
+require "spec_helper"
+
+RSpec.describe Adjective, type: :model do
+  describe "unique verbs" do
+    it "should get unique verbs ordered ascending by name" do
+      FactoryBot.create(:adjective, name: "passport")
+      FactoryBot.create(:adjective, name: "book")
+      FactoryBot.create(:adjective, name: "fine")
+
+      result = Adjective.unique_sorted
+
+      expect(result.map(&:name)).to eq(%w[book fine passport])
+    end
+  end
+end

--- a/spec/models/generic_phrase_spec.rb
+++ b/spec/models/generic_phrase_spec.rb
@@ -1,0 +1,169 @@
+require "spec_helper"
+
+RSpec.describe GenericPhrase, type: :model do
+  describe "generic phrases search" do
+    context "with empty database" do
+      it "returns no generic phrases" do
+        start_date = Date.new(2020, 3, 10)
+        end_date = Date.new(2020, 3, 15)
+
+        result = GenericPhrase.search(start_date, end_date)
+
+        expect(result).to be_empty
+      end
+    end
+
+    context "with populated database" do
+      before :each do
+        @generic_phrase = create_generic_phrase("2020-03-20", verb: "find", adjective: "help")
+      end
+
+      it "returns no generic phrases when date range matches no generic phrases" do
+        start_date = Date.new(2020, 3, 10)
+        end_date = Date.new(2020, 3, 15)
+
+        result = GenericPhrase.search(start_date, end_date)
+
+        expect(result).to be_empty
+      end
+
+      it "returns generic phrases when date range matches generic phrases" do
+        start_date = Date.new(2020, 3, 15)
+        end_date = Date.new(2020, 3, 23)
+
+        result = GenericPhrase.search(start_date, end_date)
+
+        expect(result.count).to eq(1)
+        expect(id(result.first)).to eq(@generic_phrase.id)
+        expect(generic_phrase(result.first)).to eq("#{@generic_phrase.verb.name}-#{@generic_phrase.adjective.name}")
+        expect(verb(result.first)).to eq(@generic_phrase.verb.name)
+        expect(adjective(result.first)).to eq(@generic_phrase.adjective.name)
+      end
+
+      it "returns generic phrases ordered by default sort key and direction when no sort options are specified" do
+        start_date = Date.new(2020, 3, 15)
+        end_date = Date.new(2020, 3, 23)
+        create_generic_phrase("2020-03-21", verb: "apply", adjective: "passport")
+        create_generic_phrase("2020-03-22", verb: "purchase", adjective: "book")
+        create_generic_phrase("2020-03-23", verb: "pay", adjective: "fine")
+
+        result = GenericPhrase.search(start_date, end_date)
+
+        expect(result.count).to eq(4)
+        expect(result.map { |_, generic_phrase, _, _| generic_phrase }).to eq(%w[apply-passport find-help pay-fine purchase-book])
+      end
+
+      it "returns generic phrases ordered by sort key and default sort direction when sort key is specified" do
+        start_date = Date.new(2020, 3, 15)
+        end_date = Date.new(2020, 3, 23)
+        create_generic_phrase("2020-03-21", verb: "apply", adjective: "passport")
+        create_generic_phrase("2020-03-22", verb: "purchase", adjective: "book")
+        create_generic_phrase("2020-03-23", verb: "pay", adjective: "fine")
+
+        result = GenericPhrase.search(start_date, end_date, { sort_key: "verb" })
+
+        expect(result.count).to eq(4)
+        expect(result.map { |_, _, verb, _| verb }).to eq(%w[apply find pay purchase])
+      end
+
+      it "returns generic phrases ordered by sort direction and default sort key when sort direction is specified" do
+        start_date = Date.new(2020, 3, 15)
+        end_date = Date.new(2020, 3, 23)
+        create_generic_phrase("2020-03-21", verb: "apply", adjective: "passport")
+        create_generic_phrase("2020-03-22", verb: "purchase", adjective: "book")
+        create_generic_phrase("2020-03-23", verb: "pay", adjective: "fine")
+
+        result = GenericPhrase.search(start_date, end_date, { sort_dir: "desc" })
+
+        expect(result.count).to eq(4)
+        expect(result.map { |_, _, verb, _| verb }).to eq(%w[purchase pay find apply])
+      end
+
+      it "returns generic phrases ordered by sort key and direction when sort key and direction are specified" do
+        start_date = Date.new(2020, 3, 15)
+        end_date = Date.new(2020, 3, 23)
+        create_generic_phrase("2020-03-21", verb: "apply", adjective: "passport")
+        create_generic_phrase("2020-03-22", verb: "purchase", adjective: "book")
+        create_generic_phrase("2020-03-23", verb: "pay", adjective: "fine")
+
+        result = GenericPhrase.search(start_date, end_date, { sort_key: "adj", sort_dir: "asc" })
+
+        expect(result.count).to eq(4)
+        expect(result.map { |_, _, _, adj| adj }).to eq(%w[book fine help passport])
+      end
+
+      it "returns generic phrases filtered by verb when matching verb exists as part of generic phrases" do
+        start_date = Date.new(2020, 3, 15)
+        end_date = Date.new(2020, 3, 23)
+        verb_query = "buy"
+        create_generic_phrase("2020-03-21", verb: verb_query, adjective: "books")
+        create_generic_phrase("2020-03-22", verb: verb_query, adjective: "calendars")
+
+        result = GenericPhrase.search(start_date, end_date, { verb: verb_query })
+
+        expect(result.count).to eq(2)
+        expect(generic_phrase(result.first)).to eq("#{verb_query}-books")
+        expect(generic_phrase(result.last)).to eq("#{verb_query}-calendars")
+      end
+
+      it "returns generic phrases filtered by adjective when matching adjective exists as part of generic phrases" do
+        start_date = Date.new(2020, 3, 15)
+        end_date = Date.new(2020, 3, 23)
+        adjective_query = "diary"
+        create_generic_phrase("2020-03-19", verb: "find", adjective: adjective_query)
+        create_generic_phrase("2020-03-23", verb: "purchase", adjective: adjective_query)
+
+        result = GenericPhrase.search(start_date, end_date, { adjective: adjective_query })
+
+        expect(result.count).to eq(2)
+        expect(generic_phrase(result.first)).to eq("find-#{adjective_query}")
+        expect(generic_phrase(result.last)).to eq("purchase-#{adjective_query}")
+      end
+
+      it "returns generic phrases filtered by verb and adjective when matching generic phrases exist" do
+        start_date = Date.new(2020, 3, 15)
+        end_date = Date.new(2020, 3, 23)
+        verb_query = "buy"
+        adjective_query = "diary"
+        create_generic_phrase("2020-03-21", verb: verb_query, adjective: adjective_query)
+        create_generic_phrase("2020-03-23", verb: verb_query, adjective: adjective_query)
+
+        result = GenericPhrase.search(start_date, end_date, { verb: verb_query, adjective: adjective_query })
+
+        expect(result.count).to eq(2)
+        expect(generic_phrase(result.first)).to eq("#{verb_query}-#{adjective_query}")
+        expect(generic_phrase(result.last)).to eq("#{verb_query}-#{adjective_query}")
+      end
+    end
+  end
+end
+
+def id(result)
+  result[0]
+end
+
+def generic_phrase(result)
+  result[1]
+end
+
+def verb(result)
+  result[2]
+end
+
+def adjective(result)
+  result[3]
+end
+
+def create_generic_phrase(survey_start_date, verb: "", adjective: "")
+  phrase = FactoryBot.create(:phrase)
+  survey = FactoryBot.create(:survey, started_at: survey_start_date)
+  survey_answer = FactoryBot.create(:survey_answer, survey: survey)
+  FactoryBot.create(:mention, phrase: phrase, survey_answer: survey_answer)
+
+  verb = FactoryBot.create(:verb, name: verb)
+  adjective = FactoryBot.create(:adjective, name: adjective)
+  generic_phrase = FactoryBot.create(:generic_phrase, verb: verb, adjective: adjective)
+  FactoryBot.create(:phrase_generic_phrase, phrase: phrase, generic_phrase: generic_phrase)
+
+  generic_phrase
+end

--- a/spec/models/verb_spec.rb
+++ b/spec/models/verb_spec.rb
@@ -1,0 +1,15 @@
+require "spec_helper"
+
+RSpec.describe Verb, type: :model do
+  describe "unique verbs" do
+    it "should get unique verbs ordered ascending by name" do
+      FactoryBot.create(:verb, name: "find")
+      FactoryBot.create(:verb, name: "apply")
+      FactoryBot.create(:verb, name: "renew")
+
+      result = Verb.unique_sorted
+
+      expect(result.map(&:name)).to eq(%w[apply find renew])
+    end
+  end
+end


### PR DESCRIPTION
This PR wires-up the generic phrases page with data. It adds the ability to filter generic phrases by verb and argument, sort the data in the table and paginate.

Date filtering will be added using the shared date component in a later commit.

This PR also updates the header to include the generic phrases page.