### PR TITLE
Add content pages link to navigation

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,8 +24,12 @@
     product_name: "Intent and Feedback Tool",
     navigation_items: [
       {
+          text: "Content pages",
+          href: pages_path
+      },
+      {
         text: "Generic phrases",
-        href: "/generic_phrases",
+        href: generic_phrases_path
       },
     ]
   }%>


### PR DESCRIPTION
This PR adds a link to the _Content pages_ page to the app navigation. It also changes the _Generic phrases_ page link to point to the path provided by Rails.