### PR TITLE
Allow filtering by generic phrases on content page search page

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -9,14 +9,14 @@ class PagesController < ApplicationController
   end
 
   def index
-    @presenter = PagesPresenter.new(pages, search_page, search_params, sort_key, sort_dir, from_date_as_datetime, to_date_as_datetime)
+    @presenter = PagesPresenter.new(pages, verb_results, adjective_results, search_page, search_params, search_options, from_date_as_datetime, to_date_as_datetime)
   end
 
 private
 
   def pages
     @pages ||= begin
-      Page.search_by_base_path(q, from_date_as_datetime, to_date_as_datetime, sort_key, sort_dir)
+      Page.search_by_base_path(q, from_date_as_datetime, to_date_as_datetime, search_options)
     end
   end
 
@@ -30,6 +30,14 @@ private
 
   def top_user_groups
     @top_user_groups ||= UserGroup.top_user_groups_for_page(@page, from_date_as_datetime, to_date_as_datetime).take(3)
+  end
+
+  def verb_results
+    Verb.unique_sorted.map(&:name)
+  end
+
+  def adjective_results
+    Adjective.unique_sorted.map(&:name)
   end
 
   def sort_key
@@ -46,5 +54,29 @@ private
 
   def search_page
     params[:page] ||= 0
+  end
+
+  def verb
+    verb_param = params.permit(:verb).fetch(:verb, "")
+
+    verb_results.include?(verb_param) ? verb_param : ""
+  end
+
+  def adjective
+    adjective_param = params.permit(:adjective).fetch(:adjective, "")
+
+    adjective_results.include?(adjective_param) ? adjective_param : ""
+  end
+
+  def search_options
+    options = {
+      sort_key: sort_key,
+      sort_dir: sort_dir,
+    }
+
+    options[:verb] = verb if verb.present?
+    options[:adjective] = adjective if adjective.present?
+
+    options
   end
 end

--- a/app/presenters/pages_presenter.rb
+++ b/app/presenters/pages_presenter.rb
@@ -1,15 +1,19 @@
 class PagesPresenter
   include Rails.application.routes.url_helpers
   include ActionView::Helpers::TagHelper
-  attr_reader :items
+  attr_reader :items, :verbs, :adjectives, :verb, :adjective
   delegate :page, :total_pages, :total_items, to: :pagination
 
-  def initialize(pages, search_results_page, url_params, sort_key, sort_dir, start_date, end_date)
+  def initialize(pages, verbs, adjectives, search_results_page, url_params, search_options, start_date, end_date)
     @pagination = PaginationPresenter.new(page: search_results_page, items_per_page: 50, total_items: pages.count)
     @items = pagination.paginate(pages)
+    @verbs = verbs
+    @adjectives = adjectives
     @url_params = url_params
-    @sort_key = sort_key
-    @sort_dir = sort_dir
+    @sort_key = search_options[:sort_key]
+    @sort_dir = search_options[:sort_dir]
+    @verb = search_options[:verb]
+    @adjective = search_options[:adjective]
     @start_date = start_date
     @end_date = end_date
   end

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -36,30 +36,20 @@
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-one-third">
             <%= render "govuk_publishing_components/components/select", {
-              id: "dropdown1-1",
-              full_width: true,
-              label: "What was the user trying to do?",
-              name: "verb",
-              options: [
-                {
-                  text: "Intentionally left blank",
-                  value: "option1"
-                },
-              ]
+                id: "verb-selection",
+                full_width: true,
+                label: "What was the user trying to do?",
+                name: "verb",
+                options: create_options_for_select_list(@presenter.verbs, @presenter.verb)
             } %>
           </div>
           <div class="govuk-grid-column-one-third">
             <%= render "govuk_publishing_components/components/select", {
-              id: "dropdown1-1",
-              full_width: true,
-              label: "About what?",
-              name: "argument",
-              options: [
-                {
-                  text: "Intentionally left blank",
-                  value: "option1"
-                },
-              ]
+                id: "adjective-selection",
+                full_width: true,
+                label: "About what?",
+                name: "adjective",
+                options: create_options_for_select_list(@presenter.adjectives, @presenter.adjective)
             } %>
           </div>
         </div>

--- a/spec/spec_helpers/phrase_helper.rb
+++ b/spec/spec_helpers/phrase_helper.rb
@@ -7,6 +7,9 @@ def create_phrases_for_page(page, survey_started_at, number_of_phrases, minimum_
     (index + minimum_number_of_mentions).times do
       FactoryBot.create(:mention, phrase: phrase, survey_answer: survey_answer)
     end
+
+    generic_phrase = FactoryBot.create(:generic_phrase)
+    FactoryBot.create(:phrase_generic_phrase, phrase: phrase, generic_phrase: generic_phrase)
   end
 
   visit = FactoryBot.create(:visit, visitor: visitor)


### PR DESCRIPTION
This PR allows filtering by generic phrases on the content page search page, similar to the generic pages search page.