### PR TITLE
Finish page detail

### DIFF
--- a/app/assets/stylesheets/_overwrites.scss
+++ b/app/assets/stylesheets/_overwrites.scss
@@ -29,3 +29,7 @@ span.phrase {
   margin: 0px 1px 0px 1px;
   line-height: 1.7;
 }
+
+p.inline {
+  display: inline;
+}

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -5,7 +5,7 @@ class PagesController < ApplicationController
   def show
     base_path = request.path.sub("/page", "")
     @page = Page.find_by(base_path: base_path)
-    @presenter = PagePresenter.new(@page, survey_counts, top_generic_phrases, top_user_groups)
+    @presenter = PagePresenter.new(@page, survey_counts, top_generic_phrases, top_user_groups, top_visits_last_page, top_visits_next_page, survey_answers, devices)
   end
 
   def index
@@ -38,6 +38,22 @@ private
 
   def adjective_results
     Adjective.unique_sorted.map(&:name)
+  end
+
+  def top_visits_last_page
+    @top_visits_last_page ||= Page.top_visits_last_page(@page, from_date_as_datetime, to_date_as_datetime).take(10)
+  end
+
+  def top_visits_next_page
+    @top_visits_next_page ||= Page.top_visits_next_page(@page, from_date_as_datetime, to_date_as_datetime).take(10)
+  end
+
+  def survey_answers
+    @survey_answers ||= SurveyAnswer.for_page(@page, from_date_as_datetime, to_date_as_datetime).take(3)
+  end
+
+  def devices
+    @devices ||= Device.for_page(@page, from_date_as_datetime, to_date_as_datetime)
   end
 
   def sort_key

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -10,4 +10,16 @@ class Device < ApplicationRecord
       .order("devices.id")
       .pluck("devices.name", "count(visits.device_id)")
   end
+
+  def self.for_page(page, start_date, end_date)
+    date_range = start_date..end_date
+
+    Device.joins(visits: [:page_visits, visitor: :surveys])
+      .where("page_visits.page_id" => page.id)
+      .where("surveys.started_at" => date_range)
+      .group("devices.id")
+      .order("devices.id")
+      .pluck("devices.name", "count(visits.device_id)")
+      .map { |name, visits_total| { name: name, visits_total: visits_total } }
+  end
 end

--- a/app/models/survey_answer.rb
+++ b/app/models/survey_answer.rb
@@ -19,4 +19,18 @@ class SurveyAnswer < ApplicationRecord
       .where("phrase_generic_phrases.generic_phrase_id" => generic_phrase.id, "questions.question_number" => 3, "surveys.started_at" => date_range)
       .where("survey_answers.answer not like '-'")
   end
+
+  def self.for_page(page, start_date, end_date)
+    date_range = start_date..end_date
+
+    SurveyAnswer.joins(:question, survey: [{ survey_visit: [{ visit: %i[page_visits device] }] }])
+      .where("page_visits.page_id" => page.id)
+      .where("questions.question_number" => 3)
+      .where("surveys.started_at" => date_range)
+      .where("survey_answers.answer not like '-'")
+      .pluck("survey_answers.answer", "devices.name", "surveys.started_at")
+      .map do |answer, device_name, survey_started_at|
+        { answer: answer, device_name: device_name, survey_started_at: survey_started_at }
+      end
+  end
 end

--- a/app/presenters/concerns/page_titleable.rb
+++ b/app/presenters/concerns/page_titleable.rb
@@ -1,0 +1,51 @@
+module ::PageTitleable
+  extend ActiveSupport::Concern
+
+  def page_title(base_path, items)
+    # Search API doesn't index all documents, so it won't always return
+    # a result for every base path we pass it.
+    return search_api_page_titles(items)[base_path] if search_api_page_titles(items).has_key?(base_path)
+
+    # If the search results don't include the base path we want
+    # we hit the Content Store API, which will
+    begin
+      content_store_page_title(base_path)
+    rescue GdsApi::ContentStore::ItemNotFound, GdsApi::InvalidUrl
+      # Sometimes we can have a url that the content store does not recognise
+      # because we're relying on urls from a non canonical source
+      # (for example if it has a lot of parameters in it or it's a sub item of another)
+      # We need to find a long term solution to this
+      ""
+    end
+  end
+
+  def search_api_page_titles(items)
+    return cached_search_api_page_titles[items] if cached_search_api_page_titles.has_key?(items)
+
+    search_api_results = Services.search_api.search(
+      count: items.count,
+      filter_link: items.map { |item| item[:base_path] },
+      fields: %i[link title],
+    )
+    .to_hash["results"]
+    .each_with_object({}) { |result, hash| hash[result["link"]] = result["title"] }
+
+    cached_search_api_page_titles[items] = search_api_results
+  end
+
+  def content_store_page_title(base_path)
+    return cached_content_store_page_title[base_path] if cached_content_store_page_title.has_key?(base_path)
+
+    cached_content_store_page_title[base_path] = Services.content_store.content_item(base_path)["title"]
+  end
+
+private
+
+  def cached_content_store_page_title
+    @cached_content_store_page_title ||= {}
+  end
+
+  def cached_search_api_page_titles
+    @cached_search_api_page_titles ||= {}
+  end
+end

--- a/app/presenters/page_presenter.rb
+++ b/app/presenters/page_presenter.rb
@@ -1,12 +1,18 @@
 class PagePresenter
   attr_reader :survey_counts
   delegate :base_path, :url_friendly_base_path, to: :page
+  include ActionView::Helpers::TagHelper
+  include ::PageTitleable
 
-  def initialize(page, survey_counts, top_generic_phrases, top_user_groups)
+  def initialize(page, survey_counts, top_generic_phrases, top_user_groups, top_visits_last_page, top_visits_next_page, survey_answers, devices)
     @page = page
     @survey_counts = survey_counts
     @top_generic_phrases = top_generic_phrases
     @top_user_groups = top_user_groups
+    @top_visits_last_page = top_visits_last_page
+    @top_visits_next_page = top_visits_next_page
+    @survey_answers = survey_answers
+    @devices = devices
   end
 
   def title
@@ -60,9 +66,61 @@ class PagePresenter
     end
   end
 
+  def top_visits_last_page_rows
+    top_pages_for_visits_rows(top_visits_last_page)
+  end
+
+  def top_visits_next_page_rows
+    top_pages_for_visits_rows(top_visits_next_page)
+  end
+
+  def survey_answer_text
+    survey_answers.map do |survey_answer|
+      content_tag(:p, survey_answer[:answer]) +
+        content_tag(:p, survey_answer[:device_name], class: "inline") +
+        content_tag(:p, survey_answer[:survey_started_at].strftime("%-d %B %Y"), class: "inline govuk-!-margin-left-4")
+    end
+  end
+
+  def devices_rows
+    devices.map do |device|
+      [
+        {
+          text: device[:name],
+        },
+        {
+          text: device_percentage(device[:visits_total]),
+          format: "numeric",
+        },
+      ]
+    end
+  end
+
 private
 
-  attr_reader :page, :top_user_groups, :top_generic_phrases
+  attr_reader :page, :top_user_groups, :top_generic_phrases, :top_visits_last_page, :top_visits_next_page, :survey_answers, :devices
+
+  def top_pages_for_visits_rows(top_pages)
+    top_pages.each_with_object([]) do |page, result|
+      result << [
+        {
+          text: page_title(page[:base_path], top_pages),
+        },
+        {
+          text: page[:unique_visitor_count],
+          format: "numeric",
+        },
+      ]
+    end
+  end
+
+  def device_percentage(total_for_device)
+    return "0%" if total_for_device.zero?
+
+    total = devices.map { |device| device[:visits_total] }.reduce(&:+).to_f
+    percentage = ((total_for_device.to_f / total) * 100).round(0)
+    "#{percentage}%"
+  end
 
   def content_item
     @content_item ||= begin

--- a/app/presenters/pages_presenter.rb
+++ b/app/presenters/pages_presenter.rb
@@ -52,9 +52,10 @@ private
   end
 
   def page_href(base_path)
+    p url_params
     parameters = { base_path: base_path.sub(/^\/(?!$)/, "") }
-       .merge(url_params[:from_date] || {})
-       .merge(url_params[:to_date] || {})
+       .merge(from_date: url_params[:from_date] || {})
+       .merge(to_date: url_params[:to_date] || {})
     page_path(parameters)
   end
 

--- a/app/presenters/pages_presenter.rb
+++ b/app/presenters/pages_presenter.rb
@@ -1,6 +1,7 @@
 class PagesPresenter
   include Rails.application.routes.url_helpers
   include ActionView::Helpers::TagHelper
+  include ::PageTitleable
   attr_reader :items, :verbs, :adjectives, :verb, :adjective
   delegate :page, :total_pages, :total_items, to: :pagination
 
@@ -41,10 +42,9 @@ class PagesPresenter
 private
 
   attr_reader :pagination, :url_params, :sort_key, :sort_dir, :start_date, :end_date
-  attr_accessor :page_titles
 
   def page_text(base_path)
-    title = page_title(base_path)
+    title = page_title(base_path, items)
     href = page_href(base_path)
 
     content_tag(:a, title, href: href, class: "display-block") +
@@ -56,44 +56,6 @@ private
        .merge(url_params[:from_date] || {})
        .merge(url_params[:to_date] || {})
     page_path(parameters)
-  end
-
-  def page_title(base_path)
-    # Search API doesn't index all documents, so it won't always return
-    # a result for every base path we pass it.
-    return search_api_page_titles[base_path] if search_api_page_titles.has_key?(base_path)
-
-    # If the search results don't include the base path we want
-    # we hit the Content Store API, which will
-    begin
-      content_store_page_title(base_path)
-    rescue GdsApi::ContentStore::ItemNotFound, GdsApi::InvalidUrl
-      # Sometimes we can have a url that the content store does not recognise
-      # because we're relying on urls from a non canonical source
-      # (for example if it has a lot of parameters in it or it's a sub item of another)
-      # We need to find a long term solution to this
-      ""
-    end
-  end
-
-  def search_api_page_titles
-    @search_api_page_titles ||= begin
-      Services.search_api.search(
-        count: items.count,
-        filter_link: item_base_paths,
-        fields: %i[link title],
-      )
-        .to_hash["results"]
-        .each_with_object({}) { |result, hash| hash[result["link"]] = result["title"] }
-    end
-  end
-
-  def item_base_paths
-    @item_base_paths ||= items.map { |item| item[:base_path] }
-  end
-
-  def content_store_page_title(base_path)
-    Services.content_store.content_item(base_path)["title"]
   end
 
   def page_title_head

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -49,6 +49,26 @@ This is a summary of how and where this generic phrase has been used.
               href: "#users-identify-themselves-as",
               text: "3. Users identify themselves as"
             },
+            {
+              href: "#devices-used-to-give-feedback",
+              text: "4. Devices used to give feedback"
+            },
+            {
+              href: "#user-feedback-from-user-intent-survey",
+              text: "5. User feedback from user intent survey"
+            },
+            {
+              href: "#where-do-users-come-from",
+              text: "6. Where do users come from?"
+            },
+            {
+              href: "#what-do-users-do-next",
+              text: "7. What do users do next?"
+            },
+            {
+              href: "#searches-from-page",
+              text: "8. Searches from page"
+            },
           ]
         } %>
       </div>
@@ -97,6 +117,185 @@ This is a summary of how and where this generic phrase has been used.
         } %>
       </div>
     </div>
+
+    <div class="govuk-grid-row govuk-!-margin-top-4">
+    <div class="govuk-grid-column-full">
+      <h3 class="govuk-heading-m" id="devices-used-to-give-feedback">Devices used to give feedback</h3>
+      <%= render "govuk_publishing_components/components/table", {
+        head: [
+          {
+            text: "Device"
+          },
+          {
+            text: "Percentage",
+            format: "numeric"
+          },
+        ],
+        rows: @presenter.devices_rows
+      } %>
+    </div>
+  </div>
+
+    <div class="govuk-grid-row govuk-!-margin-top-4">
+      <div class="govuk-grid-column-full">
+        <h3 class="govuk-heading-m" id="user-feedback-from-user-intent-survey">User feedback from user intent survey</h3>
+        <%= render "govuk_publishing_components/components/warning_text", {
+            text: "Content trigger warning. Some feedback can be distressing."
+        } %>
+
+        <% @presenter.survey_answer_text.each do |survey_answer| %>
+          <%= render "govuk_publishing_components/components/inset_text", {
+              text: survey_answer
+          } %>
+        <% end %>
+      </div>
+    </div>
+
+    <div class="govuk-grid-row govuk-!-margin-top-4">
+      <div class="govuk-grid-column-full">
+        <h3 class="govuk-heading-m" id="where-do-users-come-from">Where do users come from?</h3>
+        <%= render "govuk_publishing_components/components/table", {
+          head: [
+            {
+              text: "Page title"
+            },
+            {
+              text: "Number of unique visitors",
+              format: "numeric"
+            },
+          ],
+          rows: @presenter.top_visits_last_page_rows
+        } %>
+      </div>
+    </div>
+
+    <div class="govuk-grid-row govuk-!-margin-top-4">
+      <div class="govuk-grid-column-full">
+        <h3 class="govuk-heading-m" id="what-do-users-do-next">What do users do next?</h3>
+        <%= render "govuk_publishing_components/components/table", {
+          head: [
+            {
+              text: "Page title"
+            },
+            {
+              text: "Number of unique visitors",
+              format: "numeric"
+            },
+          ],
+          rows: @presenter.top_visits_next_page_rows
+        } %>
+      </div>
+    </div>
+
+    <div class="govuk-grid-row govuk-!-margin-top-4">
+      <div class="govuk-grid-column-full">
+        <h3 class="govuk-heading-m" id="searches-from-page">Searches from page</h3>
+        <%= render "govuk_publishing_components/components/table", {
+          head: [
+            {
+              text: "Search term"
+            },
+            {
+              text: "Number of on-page searches",
+              format: "numeric"
+            },
+          ],
+          rows: [
+              [
+                  {
+                      text: "Coronavirus",
+                  },
+                  {
+                      text: 123,
+                      format: "numeric",
+                  },
+              ],
+              [
+                  {
+                      text: "Self isolation",
+                  },
+                  {
+                      text: "110",
+                      format: "numeric",
+                  },
+              ],
+              [
+                  {
+                      text: "how do i register as vulnerable for food delivery",
+                  },
+                  {
+                      text: "105",
+                      format: "numeric",
+                  },
+              ],
+              [
+                  {
+                      text: "how do i register as vulnerable",
+                  },
+                  {
+                      text: "105",
+                      format: "numeric",
+                  },
+              ],
+              [
+                  {
+                      text: "registration for online shopping",
+                  },
+                  {
+                      text: "105",
+                      format: "numeric",
+                  },
+              ],
+              [
+                  {
+                      text: "self employed for 13 months",
+                  },
+                  {
+                      text: "101",
+                      format: "numeric",
+                  },
+              ],
+              [
+                  {
+                      text: "register",
+                  },
+                  {
+                      text: "89",
+                      format: "numeric",
+                  },
+              ],
+              [
+                  {
+                      text: "esa claim forms",
+                  },
+                  {
+                      text: "63",
+                      format: "numeric",
+                  },
+              ],
+              [
+                  {
+                      text: "contact options for universal credit",
+                  },
+                  {
+                      text: "42",
+                      format: "numeric",
+                  },
+              ],
+              [
+                  {
+                      text: "sign in universal credit",
+                  },
+                  {
+                      text: "12",
+                      format: "numeric",
+                  },
+              ]
+          ]
+        } %>
+      </div>
+    </div>
+
   </div>
   <div class="govuk-grid-column-one-third">
     <div class="govuk-grid-column--background-light-grey govuk-!-padding-4">

--- a/spec/models/device_spec.rb
+++ b/spec/models/device_spec.rb
@@ -48,4 +48,6 @@ RSpec.describe Device, type: :model do
       end
     end
   end
+
+  # TODO: Write spec for Device.for_page
 end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -513,6 +513,9 @@ RSpec.describe Page, type: :model do
       end
     end
   end
+
+  # TODO: Write spec for top_visits_last_page
+  # TODO: Write spec for top_visits_next_page
 end
 
 def page_base_path(result)

--- a/spec/models/survey_answer_spec.rb
+++ b/spec/models/survey_answer_spec.rb
@@ -126,6 +126,7 @@ RSpec.describe SurveyAnswer, type: :model do
       end
     end
   end
+  # TODO: Write spec for SurveyAnswer.for_page
 end
 
 def create_survey_answers_for_phrase(phrase, survey_started_at, number_of_answers = 1)


### PR DESCRIPTION
• Fixes a bug with the date not being passed through from the search page to the detail page.
- Adds remaining data for page detail page, with the following caveats:

1. The data for searches is faked. With the db structure as is it would be difficult to get this information
2. Previous/next page data isn't great. It isn't super clear to the user that this is only for visits where they provided feedback. Also, some base paths in the db include url params, so `/foo` and `foo?bar=baz` are counted as different pages even though they're not
3.  Some tests are missing in order to get this done quickly. I've added todo markers

