### PR TITLE
Update overview page to show data for the past seven days

### DIFF
--- a/app/controllers/trending_controller.rb
+++ b/app/controllers/trending_controller.rb
@@ -1,10 +1,7 @@
 class TrendingController < ApplicationController
-  attr_reader :filter_start_date, :filter_end_date
+  include Searchable
 
   def index
-    @filter_start_date = Date.new(2020, 4, 1)
-    @filter_end_date = Date.new(2020, 4, 7)
-
     @top_pages = top_pages
     @most_frequent_exact_match_phrases = most_frequent_exact_match_phrases
     @most_frequent_generic_phrases = most_frequent_generic_phrases
@@ -15,21 +12,21 @@ class TrendingController < ApplicationController
 private
 
   def top_pages
-    Page.top_pages(filter_start_date, filter_end_date).take(10)
+    Page.top_pages(from_date_as_datetime, to_date_as_datetime).take(10)
   end
 
   def most_frequent_exact_match_phrases
-    Phrase.most_frequent(filter_start_date, filter_end_date).take(10)
+    Phrase.most_frequent(from_date_as_datetime, to_date_as_datetime).take(10)
   end
 
   def most_frequent_generic_phrases
     GenericPhrase
-      .most_frequent(filter_start_date, filter_end_date)
+      .most_frequent(from_date_as_datetime, to_date_as_datetime)
       .take(10)
   end
 
   def top_user_groups
-    UserGroup.top_user_groups_by_date(filter_start_date, filter_end_date)
+    UserGroup.top_user_groups_by_date(from_date_as_datetime, to_date_as_datetime)
   end
 
   def trending_tags

--- a/spec/features/trending_spec.rb
+++ b/spec/features/trending_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "trend page" do
     @page_visit = FactoryBot.create(:page_visit, page: @top_page, visit: user_visit)
 
     @phrase = FactoryBot.create(:phrase)
-    @survey = FactoryBot.create(:survey, started_at: "2020-04-02")
+    @survey = FactoryBot.create(:survey, started_at: DateTime.now.strftime("%F"))
     @survey_answer = FactoryBot.create(:survey_answer, survey: @survey)
     FactoryBot.create(:mention, phrase: @phrase, survey_answer: @survey_answer)
     @user_group = FactoryBot.create(:user_group)


### PR DESCRIPTION
This PR updates the overview page to show data for the past seven days, as per the defaults.