### PR TITLE
Remove user groups from overview page temporarily

### DIFF
--- a/app/views/trending/index.html.erb
+++ b/app/views/trending/index.html.erb
@@ -54,13 +54,3 @@
     </div>
   </div>
 </div>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-one-half">
-    <div class="trend-group">
-      <h2 class="govuk-heading-m">Top user groups</h2>
-      <p class="govuk-body">Top user groups derived from the user intent survey responses</p>
-      <%= render "ordered_list", items: @top_user_groups, item_text_prop: :group_name, no_link: true %>
-    </div>
-  </div>
-</div>

--- a/spec/features/trending_spec.rb
+++ b/spec/features/trending_spec.rb
@@ -21,6 +21,5 @@ RSpec.feature "trend page" do
     expect(page).to have_content("Overview")
     expect(page).to have_link(@top_page.base_path, href: "https://www.gov.uk#{@top_page.base_path}")
     expect(page).to have_link(@phrase.phrase_text)
-    expect(page).to have_content(@user_group.group)
   end
 end


### PR DESCRIPTION
This PR removes user groups from overview page temporarily until we have more designs about how they might fit into the app.