### PR TITLE
Update phrase page to use date params from Searchable

### DIFF
--- a/app/controllers/mentions_controller.rb
+++ b/app/controllers/mentions_controller.rb
@@ -1,4 +1,6 @@
 class MentionsController < ApplicationController
+  include Searchable
+
   def show
     @phrase = Phrase.find(params[:id])
     @mentions = mentions
@@ -7,7 +9,7 @@ class MentionsController < ApplicationController
 private
 
   def mentions
-    Mention.mentions_by_date_range_for_phrase(@phrase, Date.new(2020, 4, 1), Date.new(2020, 4, 7))
+    Mention.mentions_by_date_range_for_phrase(@phrase, from_date_as_datetime, to_date_as_datetime)
       .sort_by { |date, _| date }
   end
 end

--- a/app/controllers/phrases_controller.rb
+++ b/app/controllers/phrases_controller.rb
@@ -1,4 +1,6 @@
 class PhrasesController < ApplicationController
+  include Searchable
+
   def show
     @phrase = Phrase.find(params[:id])
     @devices = devices
@@ -15,7 +17,7 @@ class PhrasesController < ApplicationController
 private
 
   def devices
-    device_totals = Device.breakdown_by_date_range_for_phrase(@phrase, Date.new(2020, 4, 1), Date.new(2020, 4, 7))
+    device_totals = Device.breakdown_by_date_range_for_phrase(@phrase, from_date_as_datetime, to_date_as_datetime)
 
     all_device_hits_total = device_totals.sum { |_, total| total }
 
@@ -25,18 +27,18 @@ private
   end
 
   def pages_visited
-    Page.total_visitors_for_phrase(@phrase, Date.new(2020, 4, 1), Date.new(2020, 4, 7))
+    Page.total_visitors_for_phrase(@phrase, from_date_as_datetime, to_date_as_datetime)
   end
 
   def mentions
     Mention
-      .mentions_by_date_range_for_phrase(@phrase, Date.new(2020, 4, 1), Date.new(2020, 4, 7))
+      .mentions_by_date_range_for_phrase(@phrase, from_date_as_datetime, to_date_as_datetime)
       .sort_by { |date, _| date }
       .to_h
   end
 
   def survey_answers_containing_phrase
-    SurveyAnswer.for_phrase(@phrase, Date.new(2020, 4, 1), Date.new(2020, 4, 7))
+    SurveyAnswer.for_phrase(@phrase, from_date_as_datetime, to_date_as_datetime)
   end
 
   def search_params

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -37,15 +37,18 @@ module ApplicationHelper
     links
   end
 
-  def human_readable_date_range(from, to)
+  def human_readable_date_range(from, to, alternate_text: "")
     # https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#dates
     format = "%-d %B %Y"
+    from_text = alternate_text.presence || "Showing data from"
+    to_text = alternate_text.presence || "Showing data to"
+
     if from && to
-      "Showing data from #{from.strftime(format)} to #{to.strftime(format)}"
+      "#{from_text} #{from.strftime(format)} to #{to.strftime(format)}"
     elsif from && !to
-      "Showing data from #{from.strftime(format)}"
+      "#{to_text} #{from.strftime(format)}"
     elsif !from && to
-      "Showing data to #{to.strftime(format)}"
+      "#{to_text} #{to.strftime(format)}"
     else
       "Showing all data"
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,7 +4,7 @@ module ApplicationHelper
   end
 
   def map_mentions_data_to_chart(mentions_data)
-    mentions_data.each_with_object({}) { |(date, total_mentions), hash| hash[date.strftime("%-d %b")] = total_mentions }
+    mentions_data.each_with_object({}) { |(date, total_mentions), hash| hash[date.strftime("%-d %b %Y")] = total_mentions }
   end
 
   def total_mentions(mentions_data)

--- a/app/views/mentions/show.html.erb
+++ b/app/views/mentions/show.html.erb
@@ -10,7 +10,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <div class="chart-group">
-      <span class="govuk-caption-m">Showing data from 1st to 7th April 2020</span>
+      <span class="govuk-caption-m"><%= human_readable_date_duration(from_date_as_datetime, to_date_as_datetime) %></span>
       <p class="govuk-body statistic-total"><%= number_with_delimiter(total_mentions(@mentions)) %></p>
     </div>
 

--- a/app/views/phrases/show.html.erb
+++ b/app/views/phrases/show.html.erb
@@ -4,7 +4,7 @@
     href: "/"
 } %>
 
-<span class="govuk-caption-xl">Trending phrases</span>
+<span class="govuk-caption-xl">Phrase</span>
 <h1 class="govuk-heading-xl">'<%= @phrase.phrase_text %>'</h1>
 
 <div class="govuk-grid-row">
@@ -12,7 +12,7 @@
     <div class="chart-group">
       <h2 class="govuk-heading-m">
         <%= link_to "Number of mentions", mention_path(@phrase) %>
-        <span class="govuk-caption-m">Showing data from 1st to 7th April 2020</span>
+        <span class="govuk-caption-m"><%= human_readable_date_duration(from_date_as_datetime, to_date_as_datetime) %></span>
       </h2>
 
       <p class="govuk-body statistic-total"><%= number_with_delimiter(total_mentions(@mentions)) %></p>
@@ -27,7 +27,7 @@
   <div class="govuk-grid-column-two-thirds">
     <div class="trend-group">
       <h2 class="govuk-heading-m"><%= link_to "Pages users visited", pages_visited_path(@phrase) %></h2>
-      <p class="govuk-body">Based on most pageviews for users that said <%= @phrase.phrase_text %> from 1st to 7th April 2020</p>
+      <p class="govuk-body"><%= human_readable_date_range(from_date_as_datetime, to_date_as_datetime, alternate_text: "Based on most pageviews for users that said #{@phrase.phrase_text} from ") %></p>
       <%= render 'ordered_list', items: map_pages_visited_data_to_ordered_list(@pages_visited), item_text_prop: :base_path, item_link_prop: :govuk_link %>
     </div>
   </div>
@@ -38,7 +38,7 @@
     <div class="table-group">
       <h2 class="govuk-heading-m">
         Devices used
-        <span class="govuk-caption-m">Showing data from 1st to 7th April 2020</span>
+        <span class="govuk-caption-m"><%= human_readable_date_range(from_date_as_datetime, to_date_as_datetime) %></span>
       </h2>
 
       <%= render "govuk_publishing_components/components/table", {
@@ -62,7 +62,7 @@
     <div class="text-group">
       <h2 class="govuk-heading-m">
         <%= link_to "How users used this phrase", usage_phrase_path(@phrase) %>
-        <span class="govuk-caption-m">Showing data from 1st to 7th April 2020</span>
+        <span class="govuk-caption-m"><%= human_readable_date_range(from_date_as_datetime, to_date_as_datetime) %></span>
       </h2>
 
       <% @survey_answers_containing_phrase.each do |sa| %>

--- a/spec/features/mentions_spec.rb
+++ b/spec/features/mentions_spec.rb
@@ -2,9 +2,12 @@ require "spec_helper"
 
 RSpec.feature "mentions page" do
   before :each do
+    @six_days_ago_date = DateTime.now - 6.days
+    @five_days_ago_date = DateTime.now - 5.days
+
     visitor = FactoryBot.create(:visitor)
-    survey1 = FactoryBot.create(:survey, started_at: "2020-04-02 00:00:00", visitor: visitor)
-    survey2 = FactoryBot.create(:survey, started_at: "2020-04-03 00:00:00", visitor: visitor)
+    survey1 = FactoryBot.create(:survey, started_at: @six_days_ago_date.strftime("%F"), visitor: visitor)
+    survey2 = FactoryBot.create(:survey, started_at: @five_days_ago_date.strftime("%F"), visitor: visitor)
 
     @phrase = FactoryBot.create(:phrase, phrase_text: "how government works")
     @survey_answer1 = FactoryBot.create(:survey_answer, survey: survey1, answer: "I want to understand how government works")
@@ -30,8 +33,8 @@ RSpec.feature "mentions page" do
     visit_mentions_page
 
     expect(page).to have_css(".table-group")
-    expect(page).to have_content("2nd Apr 2020 1")
-    expect(page).to have_content("3rd Apr 2020 1")
+    expect(page).to have_content("#{@six_days_ago_date.strftime("#{@six_days_ago_date.day.ordinalize} %b %Y")} 1")
+    expect(page).to have_content("#{@five_days_ago_date.strftime("#{@five_days_ago_date.day.ordinalize} %b %Y")} 1")
   end
 
   def visit_mentions_page

--- a/spec/features/phrase_spec.rb
+++ b/spec/features/phrase_spec.rb
@@ -3,8 +3,8 @@ require "spec_helper"
 RSpec.feature "phrase page" do
   before :each do
     visitor = FactoryBot.create(:visitor)
-    survey1 = FactoryBot.create(:survey, started_at: "2020-04-02 00:00:00", visitor: visitor)
-    survey2 = FactoryBot.create(:survey, started_at: "2020-04-03 00:00:00", visitor: visitor)
+    survey1 = FactoryBot.create(:survey, started_at: DateTime.now - 6.days, visitor: visitor)
+    survey2 = FactoryBot.create(:survey, started_at: DateTime.now - 5.days, visitor: visitor)
 
     @phrase = FactoryBot.create(:phrase, phrase_text: "how government works")
     @survey_answer1 = FactoryBot.create(:survey_answer, survey: survey1, answer: "I want to understand how government works")

--- a/spec/features/phrase_usages_spec.rb
+++ b/spec/features/phrase_usages_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 RSpec.feature "phrase usages" do
   scenario "displays phrase usages which contain the selected phrase" do
     phrase = FactoryBot.create(:phrase, phrase_text: "how government works")
-    survey = FactoryBot.create(:survey, started_at: "2020-04-01")
+    survey = FactoryBot.create(:survey, started_at: DateTime.now - 2.days)
     survey_answers = FactoryBot.create_list(:survey_answer, 20, survey: survey)
     survey_answers.each { |survey_answer| FactoryBot.create(:mention, phrase: phrase, survey_answer: survey_answer) }
 


### PR DESCRIPTION
This PR updates the phrase page to use date params from Searchable. The phrase page is currently only linked to from the overview page, which itself does not allow users to change the date and subsequently does not need to provide dates in the query string for the phrase page; the phrase page therefore uses the same dates without them being explicitly defined.