### PR TITLE
Fix dates on phrase usage page and pages visited page

### DIFF
--- a/app/controllers/pages_visited_controller.rb
+++ b/app/controllers/pages_visited_controller.rb
@@ -1,4 +1,6 @@
 class PagesVisitedController < ApplicationController
+  include Searchable
+
   def show
     phrase = Phrase.find(params[:id])
     @presenter = PagesVisitedPresenter.new(phrase, unique_visitors_by_page(phrase), search_params)
@@ -7,7 +9,7 @@ class PagesVisitedController < ApplicationController
 private
 
   def unique_visitors_by_page(phrase)
-    Page.unique_visitors_for_phrase(phrase, Date.new(2020, 4, 1), Date.new(2020, 4, 7))
+    Page.unique_visitors_for_phrase(phrase, from_date_as_datetime, to_date_as_datetime)
   end
 
   def search_params

--- a/app/views/phrases/usage.html.erb
+++ b/app/views/phrases/usage.html.erb
@@ -10,7 +10,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <div class="text-group">
-      <p class="govuk-body">Showing data from 1st to 7th April 2020</p>
+      <p class="govuk-body"><%= human_readable_date_range(from_date_as_datetime, to_date_as_datetime) %></p>
 
       <% @presenter.items.each do |answer| %>
         <%= render "govuk_publishing_components/components/inset_text", {

--- a/spec/features/pages_visited_spec.rb
+++ b/spec/features/pages_visited_spec.rb
@@ -3,7 +3,8 @@ require "spec_helper"
 RSpec.feature "pages visited" do
   scenario "displays pages visited" do
     visitor = FactoryBot.create(:visitor)
-    survey = FactoryBot.create(:survey, started_at: "2020-04-02 00:00:00", visitor: visitor)
+    survey_date = DateTime.now - 1.day
+    survey = FactoryBot.create(:survey, started_at: survey_date.strftime("%F"), visitor: visitor)
 
     phrase = FactoryBot.create(:phrase, phrase_text: "how government works")
     survey_answer = FactoryBot.create(:survey_answer, survey: survey)


### PR DESCRIPTION
This PR updates the phrase usage page to show the correct set of dates being searched by, and updates the pages visited page to use the correct dates to filter by as well as show them.