### PR TITLE
Add titles to content search page and content detail page pages

### DIFF
--- a/app/presenters/pages_presenter.rb
+++ b/app/presenters/pages_presenter.rb
@@ -39,6 +39,10 @@ class PagesPresenter
     ]
   end
 
+  def title
+    "Content pages with feedback comments"
+  end
+
 private
 
   attr_reader :pagination, :url_params, :sort_key, :sort_dir, :start_date, :end_date

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -1,5 +1,7 @@
+<%= content_for :title, @presenter.title %>
+
 <%= render "govuk_publishing_components/components/title", {
-    title: "Content pages with feedback comments"
+    title: @presenter.title
 } %>
 
 <div class="govuk-grid-row">

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -1,3 +1,5 @@
+<%= content_for :title, "Content detail page - #{@presenter.title}" %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <span class="govuk-caption-xl">Page with feedback from</span>


### PR DESCRIPTION
This PR adds titles to the content search page and content detail page pages, so that we can continue to distinguish how users are behaving with the prototype through GA (via Google Tag Manager).